### PR TITLE
Setup numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,14 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        'hyperspy >= 1.5', 'pyxem >= 0.9', 'numpy >= 1.16, != 1.17',
-        'h5py', 'scikit-image', 'scipy', 'dask', ],
+        'numpy>= 1.16,!= 1.17.*',
+        'hyperspy>=1.5',
+        'pyxem>=0.9',
+        'h5py',
+        'scikit-image',
+        'scipy',
+        'dask[array]',
+    ],
     package_data={
         '': ['LICENSE', 'README.md'],
         'kikuchipy': ['*.py'],

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        'numpy>= 1.16,!= 1.17.*',
+        'numpy>=1.16,!=1.17.*',
         'hyperspy>=1.5',
         'pyxem>=0.9',
         'h5py',


### PR DESCRIPTION
Make sure numpy version is not 1.17.* and above or equal to 1.16. This is because the use of `np.stack()` by HyperSpy in e.g. `_map_iterate()` throws a `ValueError`.

Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>