### PR TITLE
Tests of pattern processing and virtual imaging and override HyperSpy's as_lazy

### DIFF
--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -20,7 +20,6 @@ import gc
 import os
 import tempfile
 
-import dask.array as da
 import numpy as np
 import pytest
 

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -20,6 +20,7 @@ import gc
 import os
 import tempfile
 
+import dask.array as da
 import numpy as np
 import pytest
 

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -22,7 +22,6 @@ import logging
 import numbers
 import os
 import sys
-import warnings
 
 import dask.array as da
 import dask.diagnostics as dd
@@ -31,7 +30,6 @@ from hyperspy._lazy_signals import LazySignal2D
 from hyperspy._signals.lazy import to_array
 from hyperspy.learn.mva import LearningResults
 from hyperspy.misc.utils import DictionaryTreeBrowser
-from hyperspy.misc.array_tools import rebin
 from h5py import File
 import numpy as np
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
@@ -796,7 +794,7 @@ class EBSD(Signal2D):
 
         # Update binning in metadata
         md = out.metadata
-        ebsd_node = kp.util.io.metadata_nodes(sem=False)
+        ebsd_node = kpu.io.metadata_nodes(sem=False)
         if scale is None:
             sx = self.axes_manager.signal_shape[0]
             scale = [sx / new_shape[2]]

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -32,7 +32,7 @@ from hyperspy.learn.mva import LearningResults
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from h5py import File
 import numpy as np
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from pyxem.signals.diffraction2d import Diffraction2D
 from sklearn.decomposition import IncrementalPCA
 import tqdm
 
@@ -557,7 +557,7 @@ class EBSD(Signal2D):
           otherwise some unwanted darkening towards the edges might
           occur.
         * The default kernel size might not fit all pattern sizes, so it
-          might be necessary to search for the optimal kernel size.
+          may be necessary to search for the optimal kernel size.
         """
 
         # Determine kernel size (shape of contextual region)
@@ -567,7 +567,7 @@ class EBSD(Signal2D):
         elif isinstance(kernel_size, numbers.Number):
             kernel_size = (kernel_size,) * self.axes_manager.signal_dimension
         elif len(kernel_size) != self.axes_manager.signal_dimension:
-            ValueError(
+            raise ValueError(
                 "Incorrect value of `kernel_size`: {}".format(kernel_size))
         kernel_size = [int(k) for k in kernel_size]
 
@@ -588,57 +588,59 @@ class EBSD(Signal2D):
         else:
             self.data = equalized_patterns
 
-    def get_virtual_image(self, roi):
-        """Method imported from
-        pyxem.signals.ElectronDiffraction2D.get_virtual_image. Obtains
-        a virtual image associated with a specified ROI.
+    def virtual_forward_scatter_detector(self, roi, **kwargs):
+        """Plot an interactive virtual forward scatter detector (VFSD)
+        image formed from detector intensities within a specified and
+        adjustable region of interest (ROI).
+
+        Adapted from pyxem.signals.diffraction2d.Diffraction2D.\
+        plot_interactive_virtual_image().
 
         Parameters
         ----------
-        roi: hyperspy.roi.BaseInteractiveROI
+        roi : hyperspy.roi.BaseInteractiveROI
+            Any interactive ROI detailed in HyperSpy.
+        **kwargs:
+            Keyword arguments to be passed to `plot()`.
+
+        Examples
+        --------
+        >>> import hyperspy.api as hs
+        >>> roi = hs.roi.RectangularROI(
+                left=0, right=5, top=0, bottom=5)
+            s.virtual_forward_scatter_detector(roi)
+        """
+
+        return Diffraction2D.plot_interactive_virtual_image(
+            self, roi, **kwargs)
+
+    def get_virtual_detector_image(self, roi):
+        """Return a virtual forward scatter detector (VFSD) image
+        formed from detector intensities within a region of interest
+        (ROI).
+
+        Adapted from pyxem.signals.diffraction2d.Diffraction2D.\
+        get_virtual_image().
+
+        Parameters
+        ----------
+        roi : hyperspy.roi.BaseInteractiveROI
             Any interactive ROI detailed in HyperSpy.
 
         Returns
         -------
-        dark_field_sum: hyperspy.signals.BaseSignal
-            The virtual image signal associated with the specified roi.
+        virtual_detector_image : hyperspy.signals.BaseSignal
+            VFSD image formed from detector intensities within an ROI.
 
         Examples
         --------
-        .. code-block:: python
-
-            import hyperspy.api as hs
-            roi = hs.roi.RectangularROI(left=10, right=20, top=10,
-                bottom=20)
-            s.get_virtual_image(roi)
-        """
-        return ElectronDiffraction2D.get_virtual_image(self, roi)
-
-    def plot_interactive_virtual_image(self, roi, **kwargs):
-        """Method imported from
-        pyXem.ElectronDiffraction.plot_interactive_virtual_image(self,
-        roi). Plots an interactive virtual image formed with a
-        specified and adjustable roi.
-
-        Parameters
-        ----------
-        roi: hyperspy.roi.BaseInteractiveROI
-            Any interactive ROI detailed in HyperSpy.
-        **kwargs:
-            Keyword arguments to be passed to `ElectronDiffraction.plot`
-
-        Examples
-        --------
-        .. code-block:: python
-
-            import hyperspy.api as hs
-            roi = hs.roi.RectangularROI(left=10, right=20, top=10,
-                bottom=20)
-            s.plot_interactive_virtual_image(roi)
+        >>> import hyperspy.api as hs
+        >>> roi = hs.roi.RectangularROI(
+                left=0, right=5, top=0, bottom=5)
+            vfsd_image = s.get_virtual_detector_image(roi)
         """
 
-        return ElectronDiffraction2D.plot_interactive_virtual_image(self, roi,
-                                                                    **kwargs)
+        return Diffraction2D.get_virtual_image(self, roi)
 
     def save(
             self, filename=None, overwrite=None, extension=None,

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -21,7 +21,6 @@ import os
 import dask.array as da
 import hyperspy.api as hs
 from hyperspy.misc.utils import DictionaryTreeBrowser
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with KikuchiPy. If not, see <http://www.gnu.org/licenses/>.
 
+import dask.array as da
 from hyperspy.misc.utils import DictionaryTreeBrowser
 import numpy as np
 import pytest
 
-from kikuchipy.signals import EBSD
-from kikuchipy.util.io import metadata_nodes, kikuchipy_metadata
+import kikuchipy as kp
 
 
 def assert_dictionary(input_dict, output_dict):
@@ -47,18 +47,18 @@ class TestEBSD:
     def test_init(self):
         # Signal shape
         array0 = np.zeros(shape=(10, 10, 10, 10))
-        s0 = EBSD(array0)
+        s0 = kp.signals.EBSD(array0)
         assert array0.shape == s0.axes_manager.shape
         # Cannot initialise signal with one signal dimension
         with pytest.raises(ValueError):
-            EBSD(np.zeros(10))
+            kp.signals.EBSD(np.zeros(10))
         # Shape of one-pattern signal
         array1 = np.zeros(shape=(10, 10))
-        s1 = EBSD(array1)
+        s1 = kp.signals.EBSD(array1)
         assert array1.shape == s1.axes_manager.shape
         # SEM metadata
-        kp_md = kikuchipy_metadata()
-        sem_node = metadata_nodes(ebsd=False)
+        kp_md = kp.util.io.kikuchipy_metadata()
+        sem_node = kp.util.io.metadata_nodes(ebsd=False)
         assert_dictionary(kp_md.get_item(sem_node),
                           s1.metadata.get_item(sem_node))
         # Phases metadata
@@ -75,7 +75,7 @@ class TestEBSD:
              'manufacturer': 'NORDIF', 'version': '3.1.2',
              'microscope': 'Hitachi SU-6600', 'magnification': 500}
         dummy_signal.set_experimental_parameters(**p)
-        ebsd_node = metadata_nodes(sem=False)
+        ebsd_node = kp.util.io.metadata_nodes(sem=False)
         md_dict = dummy_signal.metadata.get_item(ebsd_node).as_dictionary()
         assert_dictionary(p, md_dict)
 
@@ -170,6 +170,29 @@ class TestEBSD:
                 dtype=np.uint8).reshape((3, 3, 3, 3))
         assert dummy_signal.data.all() == answer.all()
 
+    @pytest.mark.parametrize('static_bg, error, match', [
+        (np.ones((3, 3), dtype=np.int8), ValueError,
+         'Static background dtype_out'),
+        (None, OSError, 'Static background is not a numpy or dask array'),
+        (np.ones((3, 2), dtype=np.uint8), OSError, 'Pattern')])
+    def test_incorrect_static_background_pattern(
+            self, dummy_signal, static_bg, error, match):
+        """Test for expected error messages when passing an incorrect
+        static background pattern to `static_background_correction().`
+        """
+
+        ebsd_node = kp.util.io.metadata_nodes(sem=False)
+        dummy_signal.metadata.set_item(
+            ebsd_node + '.static_background', static_bg)
+        with pytest.raises(error, match=match):
+            dummy_signal.static_background_correction()
+
+    def test_lazy_static_background_correction(
+            self, dummy_signal, dummy_background):
+        dummy_signal = dummy_signal.as_lazy()
+        dummy_signal.static_background_correction(static_bg=dummy_background)
+        assert isinstance(dummy_signal.data, da.Array)
+
     @pytest.mark.parametrize(
         'operation, sigma', [('subtract', 2), ('subtract', 3),
                              ('divide', 2), ('divide', 3)])
@@ -221,6 +244,11 @@ class TestEBSD:
                 dtype=np.uint8).reshape((3, 3, 3, 3))
         assert dummy_signal.data.all() == answer.all()
         assert dummy_signal.data.dtype == answer.dtype
+
+    def test_lazy_dynamic_background_correction(self, dummy_signal):
+        dummy_signal = dummy_signal.as_lazy()
+        dummy_signal.dynamic_background_correction()
+        assert isinstance(dummy_signal.data, da.Array)
 
     @pytest.mark.parametrize(
         'relative, dtype_out', [(True, None), (True, np.float32),
@@ -285,3 +313,8 @@ class TestEBSD:
                 dtype=np.float32).reshape((3, 3, 3, 3))
         assert dummy_signal.data.all() == answer.all()
         assert dummy_signal.data.dtype == answer.dtype
+
+    def test_lazy_rescale_intensities(self, dummy_signal):
+        dummy_signal = dummy_signal.as_lazy()
+        dummy_signal.rescale_intensities()
+        assert isinstance(dummy_signal.data, da.Array)


### PR DESCRIPTION
Testing
* incorrect static background pattern input to `static_background_correction()`
* calling `static_background_correction()`, `dynamic_background_correction()`, `rescale_intensities()` and `adaptive_histogram_equalization()` on a `LazyEBSD` object
* interactive virtual imaging and getting an image (these are more for completion since we use pyXem's `Diffraction2D` methods without modifications and they test their methods)
* returning a `LazyEBSD` object from an `EBSD` object using `as_lazy()`

Added functionality
* overriding HyperSpy's `as_lazy()` to return a `LazyEBSD` object

Fix some errors, notably #90.

Otherwise some minor cosmetic adjustments.