### PR TITLE
Wrap change_dtype, add decomp. tests and change handling of learning results

### DIFF
--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -53,10 +53,20 @@ def dummy_background():
 
 @pytest.fixture()
 def save_path_h5ebsd():
-    """Temporary file in a temporary directory to use when tests need
+    """Temporary file in a temporary directory for use when tests need
     to write (and sometimes read again) a signal to file."""
 
     with tempfile.TemporaryDirectory() as tmp:
         file_path = os.path.join(tmp, 'patterns_temp.h5')
         yield file_path
+        gc.collect()
+
+
+@pytest.fixture()
+def temporary_dir():
+    """Temporary directory to use when tests need
+    to write (and sometimes read again) stuff to a directory."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
         gc.collect()

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -21,11 +21,13 @@ import os
 import dask.array as da
 import hyperspy.api as hs
 from hyperspy.misc.utils import DictionaryTreeBrowser
+import matplotlib
 import numpy as np
 import pytest
 
 import kikuchipy as kp
 
+matplotlib.use('Agg')  # For plotting
 
 DIR_PATH = os.path.dirname(__file__)
 KIKUCHIPY_FILE = os.path.join(DIR_PATH, '../../data/kikuchipy/patterns.h5')
@@ -373,3 +375,17 @@ class TestVirtualDetectorImaging:
         virtual_image_signal = dummy_signal.get_virtual_detector_image(roi)
         assert (virtual_image_signal.data.shape ==
                 dummy_signal.axes_manager.navigation_shape)
+
+
+class TestDecomposition:
+
+    def test_decomposition(self, dummy_signal):
+        dummy_signal.change_dtype(np.float64)
+        dummy_signal.decomposition()
+        assert isinstance(dummy_signal, kp.signals.EBSD)
+
+    def test_lazy_decomposition(self, dummy_signal):
+        lazy_signal = dummy_signal.as_lazy()
+        lazy_signal.change_dtype(np.float64)
+        lazy_signal.decomposition()
+        assert isinstance(lazy_signal, kp.signals.LazyEBSD)

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -412,7 +412,7 @@ class TestDecomposition:
             model_signal.data.mean(), mean, decimal=3)
 
     @pytest.mark.parametrize('components, intensity_mean', [
-        (None, -3.53e-08), (3, -1.17e-08), ([0, 1, 3], -5.8e-09)])
+        (None, 132.1358), (3, 122.9629), ([0, 1, 3], 116.8148)])
     def test_get_decomposition_model_lazy(
             self, dummy_signal, components, intensity_mean):
 
@@ -432,11 +432,12 @@ class TestDecomposition:
             components=components, dtype_out=np.float32)
 
         # Check data shape, signal class and pattern intensities in model
-        # signal
+        # signal after rescaling to 8 bit unsigned integer
         assert model_signal.data.shape == lazy_signal.data.shape
         assert isinstance(model_signal, kp.signals.LazyEBSD)
+        model_signal.rescale_intensities(relative=True, dtype_out=np.uint8)
         model_mean = model_signal.data.mean().compute()
-        np.testing.assert_almost_equal(model_mean, intensity_mean, decimal=8)
+        np.testing.assert_almost_equal(model_mean, intensity_mean, decimal=4)
 
     @pytest.mark.parametrize('components, mean_intensity', [
         (None, 132.1975), (3, 123.0987)])

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -411,11 +411,10 @@ class TestDecomposition:
         np.testing.assert_almost_equal(
             model_signal.data.mean(), mean, decimal=3)
 
-    @pytest.mark.parametrize('components, dtype_out, mean', [
-        (None, np.float16, -0.0001808), (None, np.float32, -1.17e-8),
-        (3, np.float16, -9.19e-5), ([0, 1, 3], np.float16, 5.58e-5)])
+    @pytest.mark.parametrize('components, intensity_mean', [
+        (None, -3.53e-08), (3, -1.17e-08), ([0, 1, 3], -5.8e-09)])
     def test_get_decomposition_model_lazy(
-            self, dummy_signal, components, dtype_out, mean):
+            self, dummy_signal, components, intensity_mean):
 
         # Decomposition
         lazy_signal = dummy_signal.as_lazy()
@@ -430,14 +429,14 @@ class TestDecomposition:
 
         # Get decomposition model
         model_signal = lazy_signal.get_decomposition_model(
-            components=components, dtype_out=dtype_out)
+            components=components, dtype_out=np.float32)
 
         # Check data shape, signal class and pattern intensities in model
         # signal
         assert model_signal.data.shape == lazy_signal.data.shape
         assert isinstance(model_signal, kp.signals.LazyEBSD)
         model_mean = model_signal.data.mean().compute()
-        np.testing.assert_almost_equal(model_mean, mean, decimal=7)
+        np.testing.assert_almost_equal(model_mean, intensity_mean, decimal=8)
 
     @pytest.mark.parametrize('components, mean_intensity', [
         (None, 132.1975), (3, 123.0987)])

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -380,12 +380,75 @@ class TestVirtualDetectorImaging:
 class TestDecomposition:
 
     def test_decomposition(self, dummy_signal):
-        dummy_signal.change_dtype(np.float64)
+        dummy_signal.change_dtype(np.float32)
         dummy_signal.decomposition()
         assert isinstance(dummy_signal, kp.signals.EBSD)
 
     def test_lazy_decomposition(self, dummy_signal):
         lazy_signal = dummy_signal.as_lazy()
-        lazy_signal.change_dtype(np.float64)
+        lazy_signal.change_dtype(np.float32)
         lazy_signal.decomposition()
         assert isinstance(lazy_signal, kp.signals.LazyEBSD)
+
+    @pytest.mark.parametrize('components, dtype_out, mean', [
+        (None, np.float16, 4.520), (None, np.float32, 4.518695),
+        (3, np.float16, 4.516), ([0, 1, 3], np.float16, 4.504)])
+    def test_get_decomposition_model(
+            self, dummy_signal, components, dtype_out, mean):
+
+        # Decomposition
+        dummy_signal.change_dtype(np.float32)
+        dummy_signal.decomposition(algorithm='svd')
+
+        # Get decomposition model
+        model_signal = dummy_signal.get_decomposition_model(
+            components=components, dtype_out=dtype_out)
+
+        # Check data shape, signal class and pattern intensities in model
+        # signal
+        assert model_signal.data.shape == dummy_signal.data.shape
+        assert isinstance(model_signal, kp.signals.EBSD)
+        np.testing.assert_almost_equal(
+            model_signal.data.mean(), mean, decimal=3)
+
+    @pytest.mark.parametrize('components, dtype_out, mean', [
+        (None, np.float16, -0.0001929), (None, np.float32, -1.17e-8),
+        (3, np.float16, -9.64e-5), ([0, 1, 3], np.float16, 0.0001929)])
+    def test_get_decomposition_model_lazy(
+            self, dummy_signal, components, dtype_out, mean):
+
+        # Decomposition
+        lazy_signal = dummy_signal.as_lazy()
+        lazy_signal.change_dtype(np.float32)
+        lazy_signal.decomposition(algorithm='PCA', output_dimension=9)
+
+        # Turn factors and loadings into dask arrays
+        lazy_signal.learning_results.factors = da.from_array(
+            lazy_signal.learning_results.factors)
+        lazy_signal.learning_results.loadings = da.from_array(
+            lazy_signal.learning_results.loadings)
+
+        # Get decomposition model
+        model_signal = lazy_signal.get_decomposition_model(
+            components=components, dtype_out=dtype_out)
+
+        # Check data shape, signal class and pattern intensities in model
+        # signal
+        assert model_signal.data.shape == lazy_signal.data.shape
+        assert isinstance(model_signal, kp.signals.LazyEBSD)
+        model_mean = model_signal.data.mean().compute()
+        np.testing.assert_almost_equal(model_mean, mean, decimal=7)
+
+    def test_rechunk_learning_results(self, dummy_signal):
+        lazy_signal = dummy_signal.as_lazy()
+        lazy_signal.change_dtype(np.float32)
+
+        with pytest.raises(ValueError, match='No learning results were found'):
+            lazy_signal._rechunk_learning_results()
+
+        lazy_signal.decomposition(algorithm='PCA', output_dimension=5)
+        lazy_signal.learning_results.loadings = \
+            lazy_signal.learning_results.loadings.T
+
+        with pytest.raises(ValueError, match='The last dimensions in factors'):
+            lazy_signal._rechunk_learning_results()

--- a/kikuchipy/signals/test/test_ebsd.py
+++ b/kikuchipy/signals/test/test_ebsd.py
@@ -372,7 +372,7 @@ class TestVirtualDetectorImaging:
 
     def test_virtual_detector_image(self, dummy_signal):
         roi = hs.roi.RectangularROI(left=0, top=0, right=1, bottom=1)
-        virtual_image_signal = dummy_signal.get_virtual_detector_image(roi)
+        virtual_image_signal = dummy_signal.get_virtual_image(roi)
         assert (virtual_image_signal.data.shape ==
                 dummy_signal.axes_manager.navigation_shape)
 
@@ -412,8 +412,8 @@ class TestDecomposition:
             model_signal.data.mean(), mean, decimal=3)
 
     @pytest.mark.parametrize('components, dtype_out, mean', [
-        (None, np.float16, -0.0001929), (None, np.float32, -1.17e-8),
-        (3, np.float16, -9.64e-5), ([0, 1, 3], np.float16, 0.0001929)])
+        (None, np.float16, -0.0001808), (None, np.float32, -1.17e-8),
+        (3, np.float16, -9.19e-5), ([0, 1, 3], np.float16, 5.58e-5)])
     def test_get_decomposition_model_lazy(
             self, dummy_signal, components, dtype_out, mean):
 
@@ -438,17 +438,3 @@ class TestDecomposition:
         assert isinstance(model_signal, kp.signals.LazyEBSD)
         model_mean = model_signal.data.mean().compute()
         np.testing.assert_almost_equal(model_mean, mean, decimal=7)
-
-    def test_rechunk_learning_results(self, dummy_signal):
-        lazy_signal = dummy_signal.as_lazy()
-        lazy_signal.change_dtype(np.float32)
-
-        with pytest.raises(ValueError, match='No learning results were found'):
-            lazy_signal._rechunk_learning_results()
-
-        lazy_signal.decomposition(algorithm='PCA', output_dimension=5)
-        lazy_signal.learning_results.loadings = \
-            lazy_signal.learning_results.loadings.T
-
-        with pytest.raises(ValueError, match='The last dimensions in factors'):
-            lazy_signal._rechunk_learning_results()

--- a/kikuchipy/util/__init__.py
+++ b/kikuchipy/util/__init__.py
@@ -16,4 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with KikuchiPy. If not, see <http://www.gnu.org/licenses/>.
 
-from kikuchipy.util import dask, experimental, general, io, nordif, phase
+from kikuchipy.util import (
+    dask, decomposition, experimental, general, io, nordif, phase)

--- a/kikuchipy/util/dask.py
+++ b/kikuchipy/util/dask.py
@@ -17,7 +17,6 @@
 # along with KikuchiPy. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 
 import dask.array as da
 import numpy as np
@@ -27,10 +26,9 @@ _logger = logging.getLogger(__name__)
 
 def _get_chunks(data_shape, dtype, mbytes_chunk=100):
     """Return suggested data chunks for patterns. Signal axes are not
-    chunked. Goals in prioritised order are (i) split into at least as
-    many chunks as available CPUs if convenient, (ii) limit chunks to
-    approximately input mega bytes, `mbytes_chunk`, and (iii) chunk only
-    one navigation axis.
+    chunked. Goals in prioritised order are (i) limit chunks to
+    approximately input mega bytes in `mbytes_chunk`, and (ii) chunk
+    only one navigation axis.
 
     Parameters
     ----------
@@ -56,14 +54,8 @@ def _get_chunks(data_shape, dtype, mbytes_chunk=100):
     nav_chunks = data_shape[:-2]
     data_nbytes = data_shape.prod() * dtype.itemsize
     pattern_size = data_nbytes / nav_chunks.prod()
-    num_chunks = np.ceil(data_nbytes / suggested_size)
     i_min, i_max = np.argmin(nav_chunks), np.argmax(nav_chunks)
-    cpus = os.cpu_count()
-    if num_chunks <= cpus:  # Return approx. as many chunks as CPUs
-        if cpus >= 4:  # But not too many chunks
-            cpus = 4
-        nav_chunks[i_max] = nav_chunks[i_max] // cpus
-    elif (nav_chunks[i_min] * pattern_size) < suggested_size:
+    if (nav_chunks[i_min] * pattern_size) < suggested_size:
         # Chunk longest navigation axis
         while (nav_chunks.prod() * pattern_size) >= suggested_size:
             nav_chunks[i_max] = np.floor(nav_chunks[i_max] / 1.1)
@@ -72,7 +64,9 @@ def _get_chunks(data_shape, dtype, mbytes_chunk=100):
             i_max = np.argmax(nav_chunks)
             nav_chunks[i_max] = np.floor(nav_chunks[i_max] / 1.1)
     chunks = list(nav_chunks) + list(sig_chunks)
+
     _logger.info("Suggested chunk size {}".format(chunks))
+
     return chunks
 
 
@@ -102,4 +96,62 @@ def _get_dask_array(signal, dtype=None):
         chunks = [8] * len(signal.axes_manager.navigation_shape)
         chunks.extend(sig_chunks)
         dask_array = da.from_array(signal.data, chunks=chunks)
+
     return dask_array.astype(dtype)
+
+
+def _rechunk_learning_results(signal, mbytes_chunk=100):
+    """Return suggested data chunks for learning results. It is assumed
+    that the loadings are not transposed. The last axes of factors and
+    loadings are not chunked. The aims in prioritised order:
+        1. Limit chunks to approx. input MB (`mbytes_chunk`).
+        2. Keep first axis of factors (detector pixels).
+
+    Parameters
+    ----------
+    signal : kp.signals.LazyEBSD
+        Signal with learning results.
+    mbytes_chunk : int, optional
+        Size of chunks in MB, default is 100 MB as suggested in the Dask
+        documentation.
+
+    Returns
+    -------
+    List of two tuples :
+        The first/second tuple are suggested chunks to pass to
+        ``dask.array.rechunk`` for factors/loadings, respectively.
+    """
+
+    target = signal.learning_results
+    if target.decomposition_algorithm is None:
+        raise ValueError("No learning results were found.")
+
+    # Get shape of learning results
+    learning_results_shape = target.factors.shape + target.loadings.shape
+
+    # Make sure the last factors/loading axes have the same shapes
+    if learning_results_shape[1] != learning_results_shape[3]:
+        raise ValueError(
+            "The last dimensions in factors and loadings are not the same.")
+
+    # Determine maximum number of (strictly necessary) chunks
+    suggested_size = mbytes_chunk * 2**20
+    factors_size = target.factors.nbytes
+    loadings_size = target.loadings.nbytes
+    total_size = factors_size + loadings_size
+    num_chunks = np.ceil(total_size / suggested_size)
+
+    # Get chunk sizes
+    if factors_size <= suggested_size:  # Chunk first axis in loadings
+        chunks = [(-1, -1), (int(learning_results_shape[2]/num_chunks), -1)]
+    else:  # Chunk both first axes
+        sizes = [factors_size, loadings_size]
+        while (sizes[0] + sizes[1]) >= suggested_size:
+            max_idx = int(np.argmax(sizes))
+            sizes[max_idx] = np.floor(sizes[max_idx] / 2)
+        factors_chunks = int(np.ceil(factors_size/sizes[0]))
+        loadings_chunks = int(np.ceil(loadings_size/sizes[1]))
+        chunks = [(int(learning_results_shape[0]/factors_chunks), -1),
+                  (int(learning_results_shape[2]/loadings_chunks), -1)]
+
+    return chunks

--- a/kikuchipy/util/decomposition.py
+++ b/kikuchipy/util/decomposition.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The KikuchiPy developers
+#
+# This file is part of KikuchiPy.
+#
+# KikuchiPy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# KikuchiPy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with KikuchiPy. If not, see <http://www.gnu.org/licenses/>.
+
+import dask.array as da
+
+import kikuchipy as kp
+
+
+def _update_learning_results(learning_results, components, dtype_out):
+    """Update learning results before calling HyperSpy's
+    get_decomposition_model() by changing data type, keeping only
+    desired components and rechunking them into suitable chunks if they
+    are lazy.
+
+    Parameters
+    ----------
+    learning_results : hyperspy.learn.mva.LearningResults
+        Learning results with component patterns and loadings.
+    components : {None, int or list of ints}
+        If None, rebuilds the signal from all components. If int,
+        rebuilds signal from components in range 0-given int. If list of
+        ints, rebuilds signal from only components in given list.
+    dtype_out : {np.float16, np.float32, np.float64}
+        Data type to cast learning results to.
+
+    Returns
+    -------
+    factors : hyperspy.learn.mva.LearningResults.factors
+        Updated component patterns in learning results.
+    loadings : hyperspy.learn.mva.LearningResults.loadings
+        Updated component loadings in learning results.
+    """
+
+    # Change data type
+    factors = learning_results.factors.astype(dtype_out)
+    loadings = learning_results.loadings.astype(dtype_out)
+
+    # Keep desired components
+    if hasattr(components, '__iter__'):  # components is a list of ints
+        factors = factors[:, components]
+        loadings = loadings[:, components]
+    else:  # components is an int
+        factors = factors[:, :components]
+        loadings = loadings[:, :components]
+
+    # Rechunk if learning results are lazy
+    if isinstance(factors, da.Array) and isinstance(loadings, da.Array):
+        chunks = kp.util.dask._rechunk_learning_results(
+            factors=factors, loadings=loadings)
+        factors = factors.rechunk(chunks=chunks[0])
+        loadings = loadings.rechunk(chunks=chunks[1])
+
+    return factors, loadings

--- a/kikuchipy/util/test/test_dask.py
+++ b/kikuchipy/util/test/test_dask.py
@@ -18,6 +18,7 @@
 
 import os
 
+import dask.array as da
 import numpy as np
 import pytest
 
@@ -39,12 +40,7 @@ class TestDask:
         elif mbytes_chunk == 50:
             nx, ny = (66, 200)
         else:  # mbytes_chunk == 100
-            # Here we assume that the computer running the tests have four CPUs
-            # or more... don't know how to test functions using os.cpu_counts().
-            if os.cpu_count() >= 4:
-                nx, ny = (74, 200)
-            else:
-                nx, ny = (136, 200)
+            nx, ny = (136, 200)
         assert chunks == [ny, nx, 60, 60]
 
     def test_get_dask_array(self):
@@ -57,3 +53,32 @@ class TestDask:
         s.data = dask_array.rechunk((5, 5, 120, 120))
         dask_array = kp.util.dask._get_dask_array(s)
         assert dask_array.chunksize == (5, 5, 120, 120)
+
+    def test_rechunk_learning_results(self):
+        data = da.from_array(np.random.rand(10, 100, 100, 5).astype(np.float32))
+        lazy_signal = kp.signals.LazyEBSD(data)
+
+        # Raise error when signal has no learning result
+        with pytest.raises(ValueError, match='No learning results were found'):
+            kp.util.dask._rechunk_learning_results(signal=lazy_signal)
+
+        # Raise error when last dimension in factors/loadings are not identical
+        lazy_signal.decomposition(algorithm='PCA', output_dimension=10)
+        lazy_signal.learning_results.loadings = \
+            lazy_signal.learning_results.loadings.T
+        with pytest.raises(ValueError, match='The last dimensions in factors'):
+            kp.util.dask._rechunk_learning_results(signal=lazy_signal)
+
+        # Revert to correct learning results shape
+        lazy_signal.learning_results.loadings = \
+            lazy_signal.learning_results.loadings.T
+
+        # Only chunk first axis in loadings
+        chunks = kp.util.dask._rechunk_learning_results(
+            signal=lazy_signal, mbytes_chunk=0.02)
+        assert chunks == [(-1, -1), (200, -1)]
+
+        # Chunk first axis in both loadings and factors
+        chunks = kp.util.dask._rechunk_learning_results(
+            signal=lazy_signal, mbytes_chunk=0.01)
+        assert chunks == [(125, -1), (62, -1)]


### PR DESCRIPTION
Wrap HyperSpy's `change_dtype()` to maintain `EBSD` and `LazyEBSD` classes.

Finish `get_decomposition_model()` decomposition tests.

Move preparation of learning results before calling HyperSpy's `get_decomposition_model()` to it's own utility file, in an effort to keep `ebsd.py` as light as possible.

Remove the condition that number of chunks of patterns or learning results have to be equal or more than available cpus or below four... Difficult to test on TravisCI, and it's been too long since I added the functionality to remember why it was necessary.