### PR TITLE
Add Windows, macOS, and pip to Travis CI runs + minor doc changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: shell
+language: generic
 
 env:
   global:
@@ -7,12 +7,15 @@ env:
 
 matrix:
   include:
-    - env: export PYTHON=3.7
-      os: linux
-    - env: export PYTHON=3.7
-      os: osx
-#    - env: export PYTHON=3.7
-#      os: windows
+    - os: linux
+      env: export PYTHON=3.7
+      language: python
+    - os: osx
+      env: export PYTHON=3.7
+      language: shell
+#    - os: windows
+#      env: export PYTHON=3.7
+#      language: shell
 
 sudo: True # for Miniconda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ matrix:
     # Windows
 #    - os: windows
     - os: windows
-      language: python
-      python: 3.7
       env: export ENV=pip
 
 sudo: True # for Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ matrix:
 #            - python3
 
     # Windows
-    - os: windows
 #    - os: windows
-#      env: export ENV=pip
+    - os: windows
+      env: export ENV=pip
 
 sudo: True # for Miniconda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
     # macOS
     # conda
-#    - os: osx
+    - os: osx
     # pip
     - os: osx
       env: export ENV=pip
@@ -35,11 +35,11 @@ matrix:
 
     # Windows
     # conda
-#    - os: windows
-#      env: PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
+    - os: windows
+      env: PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
     # pip
-#    - os: windows
-#      env: export ENV=pip; PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+    - os: windows
+      env: export ENV=pip; PATH="/c/Python37:/c/Python37/Scripts:$PATH"
 
 sudo: True # for Miniconda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   include:
     - env: export PYTHON=3.7
       os: linux
-#    - env: export PYTHON=3.7
-#      os: windows
+    - env: export PYTHON=3.7
+      os: windows
 #    - env: export PYTHON=3.7
 #      os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
     # Windows
 #    - os: windows
     - os: windows
+      language: python
+      python: 3.7
       env: export ENV=pip
 
 sudo: True # for Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     # macOS
     # conda
     - os: osx
+      osx_image: xcode11.2
     # pip
     - os: osx
       env: export ENV=pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
     - os: osx
       env: export PYTHON=3.7
       language: shell
-#    - os: windows
-#      env: export PYTHON=3.7
-#      language: shell
+    - os: windows
+      env: export PYTHON=3.7
+      language: shell
 
 sudo: True # for Miniconda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ matrix:
 #    - os: osx
     - os: osx
       env: export ENV=pip
+      addons:
+        homebrew:
+          update: true # Takes time, might not be necessary
+          packages:
+            - python3
 
     # Windows
 #    - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ sudo: True # for Miniconda
 before_install:
   # Set up conda for the different operating systems
   - if [ $ENV == conda ]; then
-      source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh
+      source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ sudo: True # for Miniconda
 
 before_install:
   # Set up conda for the different operating systems
-  - if [ $ENV == conda ]; then
+  - if [ "$ENV" == conda ]; then
       source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: shell
 
 env:
   global:
@@ -9,30 +9,19 @@ matrix:
   include:
     - env: export PYTHON=3.7
       os: linux
-    - env: export PYTHON=3.7
-      os: windows
+#    - env: export PYTHON=3.7
+#      os: windows
+#      language: shell
 #    - env: export PYTHON=3.7
 #      os: osx
 
 sudo: True # for Miniconda
 
 before_install:
-  # Install Miniconda
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - chmod +x miniconda.sh;
-    ./miniconda.sh -b -p $HOME/miniconda;
-    hash -r
-  # Setup environment
-  - source $HOME/miniconda/bin/activate root;
-    conda update --yes conda;
-    conda config --append channels conda-forge;
-    conda create --name testenv --yes python=$PYTHON;
-    conda activate testenv
-  - conda info -a
-  - df -h
+  - source ./ci/travis_setup_conda_linux.sh
 
 install:
-  - conda install --yes $DEPS $TEST_DEPS
+  - source ./ci/travis_install_with_conda.sh
   - pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,33 @@ env:
 
 matrix:
   include:
-
     # Linux (Ubuntu)
+    # conda
 #    - os: linux
-#    - os: linux
-#      language: python
-#      python: 3.7
-#      env: export ENV=pip
+    # pip
+    - os: linux
+      language: python
+      python: 3.7
+      env: export ENV=pip
 
     # macOS
+    # conda
 #    - os: osx
-#    - os: osx
-#      env: export ENV=pip
-#      addons:
-#        homebrew:
-#          packages:
-#            - python3
+    # pip
+    - os: osx
+      env: export ENV=pip
+      addons:
+        homebrew:
+          packages:
+            - python3
 
     # Windows
-    - os: windows
-      env: PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
-    - os: windows
-      env: export ENV=pip; PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+    # conda
+#    - os: windows
+#      env: PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
+    # pip
+#    - os: windows
+#      env: export ENV=pip; PATH="/c/Python37:/c/Python37/Scripts:$PATH"
 
 sudo: True # for Miniconda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
 install:
   - source ./ci/travis_install_with_conda.sh
-  - pip install .
+  - pip install -e .
 
 script:
   - export MPLBACKEND=Agg

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # systems is based upon HyperSpy:
 # https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/.travis.yml
 
-language: shell
+language: python
 
 env:
   global:
@@ -21,6 +21,7 @@ matrix:
 #    - os: osx
 #      env: export ENV=pip
     - os: windows
+      language: shell
 #    - os: windows
 #      env: export ENV=pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ matrix:
 
     # Linux (Ubuntu)
 #    - os: linux
-    - os: linux
-      language: python
-      python: 3.7
-      env: export ENV=pip
+#    - os: linux
+#      language: python
+#      python: 3.7
+#      env: export ENV=pip
 
     # macOS
 #    - os: osx
@@ -31,7 +31,7 @@ matrix:
 #            - python3
 
     # Windows
-#    - os: windows
+    - os: windows
 #    - os: windows
 #      env: export ENV=pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,40 @@
-language: generic
+# The setup of different files for installation and tests on different operating
+# systems is based upon HyperSpy:
+# https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/.travis.yml
+
+language: shell
 
 env:
   global:
+    - ENV=conda
     - DEPS="hyperspy pyxem dask[array] h5py matplotlib numpy scikit-image scikit-learn scipy"
     - TEST_DEPS="pytest pytest-cov coveralls"
+    - PYTHON_CONDA=3.7
 
 matrix:
   include:
     - os: linux
-      env: export PYTHON=3.7
-      language: python
+    - os: linux
+      env: export ENV=pip
+      python: 3.7
     - os: osx
-      env: export PYTHON=3.7
-      language: shell
+#    - os: osx
+#      env: export ENV=pip
     - os: windows
-      env: export PYTHON=3.7
-      language: shell
+#    - os: windows
+#      env: export ENV=pip
 
 sudo: True # for Miniconda
 
 before_install:
-  - source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh
+  # Set up conda for the different operating systems
+  - if [ $ENV == conda ]; then
+      source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh
+    fi
 
 install:
-  - source ./ci/travis_install_with_conda.sh
+  # Install dependencies with conda or pip
+  - source ./ci/travis_install_with_$ENV.sh
   - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,10 @@ matrix:
 #            - python3
 
     # Windows
-#    - os: windows
     - os: windows
-      env: export ENV=pip
+      env: PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
+    - os: windows
+      env: export ENV=pip; PATH="/c/Python37:/c/Python37/Scripts:$PATH"
 
 sudo: True # for Miniconda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - ENV=conda
     - DEPS="hyperspy pyxem dask[array] h5py matplotlib numpy scikit-image scikit-learn scipy"
-    - TEST_DEPS="pytest pytest-cov coveralls"
+    - TEST_DEPS="pytest pytest-cov coveralls==4.5.4"
     - PYTHON_CONDA=3.7
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # The setup of different files for installation and tests on different operating
-# systems is based upon HyperSpy:
+# systems are based upon HyperSpy:
 # https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/.travis.yml
 
 language: shell
@@ -13,11 +13,15 @@ env:
 
 matrix:
   include:
-    - name: "Python 3.7 with conda on Linux Ubuntu 16.04"
+    - name: "Python 3.7 with conda on Linux Ubuntu 18.04"
       os: linux
+      dist: bionic
+      language: python
+      python: 3.7
 
-    - name: "Python 3.7 with pip on Linux Ubuntu 16.04"
+    - name: "Python 3.7 with pip on Linux Ubuntu 18.04"
       os: linux
+      dist: bionic
       language: python
       python: 3.7
       env: export ENV=pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,34 @@ env:
 
 matrix:
   include:
-    # Linux (Ubuntu)
-    # conda
-#    - os: linux
-    # pip
-    - os: linux
+    - name: "Python 3.7 with conda on Linux Ubuntu 16.04"
+      os: linux
+
+    - name: "Python 3.7 with pip on Linux Ubuntu 16.04"
+      os: linux
       language: python
       python: 3.7
       env: export ENV=pip
 
-    # macOS
-    # conda
-    - os: osx
-      osx_image: xcode11.2
-    # pip
-    - os: osx
+    - name: "Python 3.7 with conda on macOS 10.14"
+      os: osx
+      osx_image: xcode11.3
+
+    - name: "Python 3.7 with pip on macOS 10.14"
+      os: osx
+      osx_image: xcode11.3
       env: export ENV=pip
       addons:
         homebrew:
           packages:
             - python3
 
-    # Windows
-    # conda
-    - os: windows
+    - name: "Python 3.7 with conda on Windows Server, version 1803"
+      os: windows
       env: PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
-    # pip
-    - os: windows
+
+    - name: "Python 3.7 with pip on Windows Server, version 1803"
+      os: windows
       env: export ENV=pip; PATH="/c/Python37:/c/Python37/Scripts:$PATH"
 
 sudo: True # for Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env: export ENV=pip
       addons:
         homebrew:
-          update: true # Takes time, might not be necessary
+#          update: true # Takes time, might not be necessary
           packages:
             - python3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,21 @@ env:
 
 matrix:
   include:
-    - os: linux
-    - os: linux
-      language: python
-      python: 3.7
-      env: export ENV=pip
-    - os: osx
-#    - os: osx
+
+    # Linux (Ubuntu)
+#    - os: linux
+#    - os: linux
+#      language: python
+#      python: 3.7
 #      env: export ENV=pip
-    - os: windows
+
+    # macOS
+#    - os: osx
+    - os: osx
+      env: export ENV=pip
+
+    # Windows
+#    - os: windows
 #    - os: windows
 #      env: export ENV=pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - ENV=conda
     - DEPS="hyperspy pyxem dask[array] h5py matplotlib numpy scikit-image scikit-learn scipy"
-    - TEST_DEPS="pytest pytest-cov coveralls==4.5.4"
+    - TEST_DEPS="pytest pytest-cov coveralls coverage==4.5.4"
     - PYTHON_CONDA=3.7
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # systems is based upon HyperSpy:
 # https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/.travis.yml
 
-language: python
+language: shell
 
 env:
   global:
@@ -15,13 +15,13 @@ matrix:
   include:
     - os: linux
     - os: linux
-      env: export ENV=pip
+      language: python
       python: 3.7
+      env: export ENV=pip
     - os: osx
 #    - os: osx
 #      env: export ENV=pip
     - os: windows
-      language: shell
 #    - os: windows
 #      env: export ENV=pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ matrix:
 
     # Linux (Ubuntu)
 #    - os: linux
-#    - os: linux
-#      language: python
-#      python: 3.7
-#      env: export ENV=pip
+    - os: linux
+      language: python
+      python: 3.7
+      env: export ENV=pip
 
     # macOS
 #    - os: osx
@@ -27,7 +27,6 @@ matrix:
       env: export ENV=pip
       addons:
         homebrew:
-#          update: true # Takes time, might not be necessary
           packages:
             - python3
 
@@ -47,6 +46,8 @@ before_install:
 install:
   # Install dependencies with conda or pip
   - source ./ci/travis_install_with_$ENV.sh
+
+  # Install KikuchiPy
   - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ matrix:
 
     # macOS
 #    - os: osx
-    - os: osx
-      env: export ENV=pip
-      addons:
-        homebrew:
-          packages:
-            - python3
+#    - os: osx
+#      env: export ENV=pip
+#      addons:
+#        homebrew:
+#          packages:
+#            - python3
 
     # Windows
 #    - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,15 @@ matrix:
   include:
     - env: export PYTHON=3.7
       os: linux
+    - env: export PYTHON=3.7
+      os: osx
 #    - env: export PYTHON=3.7
 #      os: windows
-#      language: shell
-#    - env: export PYTHON=3.7
-#      os: osx
 
 sudo: True # for Miniconda
 
 before_install:
-  - source ./ci/travis_setup_conda_linux.sh
+  - source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh
 
 install:
   - source ./ci/travis_install_with_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ language: python
 
 env:
   global:
-    - DEPS="hyperspy pyxem"
+    - DEPS="hyperspy pyxem dask[array] h5py matplotlib numpy scikit-image scikit-learn scipy"
     - TEST_DEPS="pytest pytest-cov coveralls"
 
 matrix:
   include:
     - env: export PYTHON=3.7
+      os: linux
+#    - env: export PYTHON=3.7
+#      os: windows
+#    - env: export PYTHON=3.7
+#      os: osx
 
 sudo: True # for Miniconda
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,5 +44,16 @@ All code in KikuchiPy is formatted according to the `Style Guide for Python Code
 Writing documentation
 =====================
 
-KikuchiPy uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for
-documenting functionality.
+We use `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for documenting
+functionality.
+
+.. _continuous-integration:
+
+Continuous integration (CI)
+===========================
+
+We use `Travis CI <https://travis-ci.org/kikuchipy/kikuchipy>`_ to ensure that
+KikuchiPy can be installed on Windows, macOS and Linux (Ubuntu) with both
+``conda`` and ``pip``. After a successful installation, the CI server runs the
+tests. After the tests return no errors, code coverage is reported to
+`Coveralls <https://coveralls.io/github/kikuchipy/kikuchipy?branch=master>`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,6 @@
-======================
-Development guidelines
-======================
+============
+Contributing
+============
 
 KikuchiPy is meant to be a community maintained project. We welcome
 contributions in the form of bug reports, documentation, code, feature requests,
@@ -39,10 +39,10 @@ Code formatting
 All code in KikuchiPy is formatted according to the `Style Guide for Python Code
 <https://www.python.org/dev/peps/pep-0008/>`_.
 
-.. _contributing-to-documentation:
+.. _writing-documentation:
 
-Contributing to documentation
-=============================
+Writing documentation
+=====================
 
 KikuchiPy uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for
-documentation.
+documenting functionality.

--- a/README.md
+++ b/README.md
@@ -10,37 +10,18 @@ inherits all relevant methods from HyperSpy's `Signal2D` and `Signal` classes.
 
 KikuchiPy is released under the GPL v3 license.
 
-#### Installation
-```bash
-$ conda create --name kikuchi python=3
-$ conda activate kikuchi
-$ conda install hyperspy pyxem --channel conda-forge
-$ pip install https://github.com/kikuchipy/kikuchipy/archive/master.zip
-```
+##### User guide
 
-#### Use
-```python
-import kikuchipy as kp
-s = kp.load('/some/data.h5')
-s.static_background_correction()
-s.dynamic_background_correction()
-s.adaptive_histogram_equalization()
-s.save('/some/processed_data.h5')  # E.g. for subsequent indexing with EMsoft
-```
+Installation instructions, a user guide and the full API reference is available
+[here](https://kikuchipy.readthedocs.io) via Read the Docs.
 
-#### Supported EBSD formats
-* NORDIF .dat binary files (read/write)
-* HyperSpy's .hspy files (read/write)
-* h5ebsd files, specifically EDAX's and Bruker's formats (read) and
-KikuchiPy's own format (read/write)
+##### Contributing
 
-Readers for more formats will be added.
+Everyone is welcome to contribute. Please read our
+[contributor guide](https://kikuchipy.readthedocs.io/contributing.html) to get
+started!
 
-#### Contribute
-Everyone is welcome to contribute, if it is by raising issues in the
-[issue tracker](https://github.com/kikuchipy/kikuchipy/issues) or by
-contributing code in [pull requests](https://github.com/kikuchipy/kikuchipy/pulls).
+##### Cite
 
-#### Cite
-If analysis using KikuchiPy forms a part of published work please consider
+If analysis using KikuchiPy forms a part of published work, please consider
 recognizing the code development, by for now citing HyperSpy.

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -1,5 +1,5 @@
 # Configure conda
-if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
+if [[ $TRAVIS_OS_NAME =~ ^(linux|osx)$ ]]; then
   source $HOME/miniconda/bin/activate root
 fi
 
@@ -7,7 +7,7 @@ conda update --yes conda
 conda config --append channels conda-forge
 conda create --name testenv --yes python=$PYTHON_CONDA
 
-if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
+if [[ $TRAVIS_OS_NAME =~ ^(linux|osx)$ ]]; then
   conda activate testenv
 else # windows
   . activate testenv

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -2,6 +2,7 @@
 if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
   source $HOME/miniconda/bin/activate root
 fi
+
 conda update --yes conda
 conda config --append channels conda-forge
 conda create --name testenv --yes python=$PYTHON

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -5,7 +5,7 @@ fi
 
 conda update --yes conda
 conda config --append channels conda-forge
-conda create --name testenv --yes python=$PYTHON
+conda create --name testenv --yes python=$PYTHON_CONDA
 
 if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
   conda activate testenv

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -1,5 +1,5 @@
 # Configure conda
-if [[ $TRAVIS_OS_NAME =~ ^(linux|osx)$ ]]; then
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
   source $HOME/miniconda/bin/activate root
 fi
 
@@ -7,7 +7,7 @@ conda update --yes conda
 conda config --append channels conda-forge
 conda create --name testenv --yes python=$PYTHON_CONDA
 
-if [[ $TRAVIS_OS_NAME =~ ^(linux|osx)$ ]]; then
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
   conda activate testenv
 else # windows
   . activate testenv

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -1,0 +1,10 @@
+# Configure conda
+source $HOME/miniconda/bin/activate root
+conda update --yes conda
+conda config --append channels conda-forge
+conda create --name testenv --yes python=$PYTHON
+conda activate testenv
+
+# Install package with conda
+conda install --yes $DEPS $TEST_DEPS
+conda info

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -1,9 +1,16 @@
 # Configure conda
-source $HOME/miniconda/bin/activate root
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
+  source $HOME/miniconda/bin/activate root
+fi
 conda update --yes conda
 conda config --append channels conda-forge
 conda create --name testenv --yes python=$PYTHON
-conda activate testenv
+
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
+  conda activate testenv
+else # windows
+  . activate testenv
+fi
 
 # Install package with conda
 conda install --yes $DEPS $TEST_DEPS

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -18,13 +18,13 @@ fi
 pip3 --version
 
 # Create and activate virtual environment
-#if [ "$TRAVIS_OS_NAME" == linux ]; then
-#  python3 -m pip3 install --upgrade virtualenv
-#  virtualenv -p python3 --system-site-packages $HOME/testenv
-#else # windows/osx
-python -m pip install --upgrade virtualenv
-virtualenv -p python --system-site-packages $HOME/testenv
-#fi
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|windows)$ ]]; then
+  python -m pip install --upgrade virtualenv
+  virtualenv -p python --system-site-packages $HOME/testenv
+else # osx
+  python3 -m pip3 install --upgrade virtualenv
+  virtualenv -p python3 --system-site-packages $HOME/testenv
+fi
 source $HOME/testenv/bin/activate
 
 # Install package with pip

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,17 +1,32 @@
-# Install Python3
-#if [ "$TRAVIS_OS_NAME" == windows ]; then
-#  choco install -y python3 --version=3.7.5 --allow-downgrades
-#fi
+# According to
+# https://github.com/cclauss/Travis-CI-Python-on-three-OSes/blob/master/.travis.yml:
+# 'python' points to Python 2.7 on macOS, but points to Python 3.7 on Linux and Windows
+# 'python3' is a 'command not found' error on Windows, but 'python' works on Windows only
+
+# Install Python3 on Windows
+if [ "$TRAVIS_OS_NAME" == windows ]; then
+  choco install -y python --version=3.7.5 --allow-downgrades
+  python -m pip install --upgrade pip
+fi
 
 # Check Python and pip version
-python3 --version
-pip --version
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
+  python3 --version
+else # windows
+  python --version
+fi
+pip3 --version
 
 # Create virtual environment
-python3 -m pip install --upgrade virtualenv
-virtualenv -p python3 --system-site-packages $HOME/testenv
+if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
+  python3 -m pip3 install --upgrade virtualenv
+  virtualenv -p python3 --system-site-packages $HOME/testenv
+else # windows
+  python -m pip3 install --upgrade virtualenv
+  virtualenv -p python --system-site-packages $HOME/testenv
+fi
 source $HOME/testenv/bin/activate
 
 # Install package with pip
-pip install --upgrade $DEPS $TEST_DEPS
-pip list installed
+pip3 install --upgrade $DEPS $TEST_DEPS
+pip3 list installed

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,10 +1,15 @@
+# Install Python3
+if [ "$TRAVIS_OS_NAME" == windows ]; then
+  choco install -y python3 --version=3.7.5 --allow-downgrades
+fi
+
 # Check Python and pip version
-python --version
+python3 --version
 pip --version
 
 # Create virtual environment
-python -m pip install --upgrade virtualenv
-virtualenv -p python --system-site-packages $HOME/testenv
+python3 -m pip install --upgrade virtualenv
+virtualenv -p python3 --system-site-packages $HOME/testenv
 source $HOME/testenv/bin/activate
 
 # Install package with pip

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,8 +1,16 @@
+# Check Python and pip version
+python3 -V
+pip -V
+
+python3 -m pip install --upgrade virtualenv
+virtualenv -p python3 --system-site-packages $HOME/venv
+source $HOME/venv/bin/activate
+
 # Install package with pip
-if [[ $TRAVIS_OS_NAME =~ ^(osx|windows)$ ]]; then
-  pip3 install -U $DEPS $TEST_DEPS
-  pip3 list installed
-else # linux
-  pip install -U $DEPS $TEST_DEPS
-  pip list installed
-fi
+#if [[ $TRAVIS_OS_NAME =~ ^(osx|windows)$ ]]; then
+#  pip3 install -U $DEPS $TEST_DEPS
+#  pip3 list installed
+#else # linux
+pip install --upgrade $DEPS $TEST_DEPS
+pip list installed
+#fi

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,0 +1,3 @@
+# Install package with pip
+pip install -U $DEPS $TEST_DEPS
+pip list installed

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,3 +1,8 @@
 # Install package with pip
-pip install -U $DEPS $TEST_DEPS
-pip list installed
+if [[ $TRAVIS_OS_NAME =~ ^(osx|windows)$ ]]; then
+  pip3 install -U $DEPS $TEST_DEPS
+  pip3 list installed
+else # linux
+  pip install -U $DEPS $TEST_DEPS
+  pip list installed
+fi

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,16 +1,12 @@
 # Check Python and pip version
-python3 -V
-pip -V
+python3 --version
+pip --version
 
+# Create virtual environment
 python3 -m pip install --upgrade virtualenv
-virtualenv -p python3 --system-site-packages $HOME/venv
-source $HOME/venv/bin/activate
+virtualenv -p python3 --system-site-packages $HOME/testenv
+source $HOME/testenv/bin/activate
 
 # Install package with pip
-#if [[ $TRAVIS_OS_NAME =~ ^(osx|windows)$ ]]; then
-#  pip3 install -U $DEPS $TEST_DEPS
-#  pip3 list installed
-#else # linux
 pip install --upgrade $DEPS $TEST_DEPS
 pip list installed
-#fi

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -9,5 +9,4 @@ source $HOME/testenv/bin/activate
 
 # Install package with pip
 pip install --upgrade $DEPS $TEST_DEPS
-#pip install --upgrade pip # To solve coverage conflict between python-coveralls and pytest-cov
 pip list installed

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -3,7 +3,7 @@
 # 'python' points to Python 2.7 on macOS, but points to Python 3.7 on Linux and Windows
 # 'python3' is a 'command not found' error on Windows, but 'python' works on Windows only
 
-# Install Python on Windows
+# Install Python version 3.7 on Windows
 if [ "$TRAVIS_OS_NAME" == windows ]; then
   choco install -y python --version=3.7.5 --allow-downgrades
   python -m pip install --upgrade pip

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,7 +1,7 @@
 # Install Python3
-if [ "$TRAVIS_OS_NAME" == windows ]; then
-  choco install -y python3 --version=3.7.5 --allow-downgrades
-fi
+#if [ "$TRAVIS_OS_NAME" == windows ]; then
+#  choco install -y python3 --version=3.7.5 --allow-downgrades
+#fi
 
 # Check Python and pip version
 python3 --version

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -18,13 +18,13 @@ fi
 pip3 --version
 
 # Create and activate virtual environment
-if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
-  python3 -m pip3 install --upgrade virtualenv
-  virtualenv -p python3 --system-site-packages $HOME/testenv
-else # windows
-  python -m pip install --upgrade virtualenv
-  virtualenv -p python --system-site-packages $HOME/testenv
-fi
+#if [ "$TRAVIS_OS_NAME" == linux ]; then
+#  python3 -m pip3 install --upgrade virtualenv
+#  virtualenv -p python3 --system-site-packages $HOME/testenv
+#else # windows/osx
+python -m pip install --upgrade virtualenv
+virtualenv -p python --system-site-packages $HOME/testenv
+#fi
 source $HOME/testenv/bin/activate
 
 # Install package with pip

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -22,7 +22,7 @@ if [[ "$TRAVIS_OS_NAME" =~ ^(linux|windows)$ ]]; then
   python -m pip install --upgrade virtualenv
   virtualenv -p python --system-site-packages $HOME/testenv
 else # osx
-  python3 -m pip3 install --upgrade virtualenv
+  python3 -m pip install --upgrade virtualenv
   virtualenv -p python3 --system-site-packages $HOME/testenv
 fi
 source $HOME/testenv/bin/activate

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -3,9 +3,8 @@
 # 'python' points to Python 2.7 on macOS, but points to Python 3.7 on Linux and Windows
 # 'python3' is a 'command not found' error on Windows, but 'python' works on Windows only
 
-# Install Python3 on Windows
+# Install Python on Windows
 if [ "$TRAVIS_OS_NAME" == windows ]; then
-  PATH="/c/Python37:/c/Python37/Scripts:$PATH"
   choco install -y python --version=3.7.5 --allow-downgrades
   python -m pip install --upgrade pip
 fi
@@ -18,7 +17,7 @@ else # windows
 fi
 pip3 --version
 
-# Create virtual environment
+# Create and activate virtual environment
 if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
   python3 -m pip3 install --upgrade virtualenv
   virtualenv -p python3 --system-site-packages $HOME/testenv

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -9,4 +9,5 @@ source $HOME/testenv/bin/activate
 
 # Install package with pip
 pip install --upgrade $DEPS $TEST_DEPS
+#pip install --upgrade pip # To solve coverage conflict between python-coveralls and pytest-cov
 pip list installed

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -5,8 +5,9 @@
 
 # Install Python3 on Windows
 if [ "$TRAVIS_OS_NAME" == windows ]; then
-  choco install -y python --version=3.7.5 --allow-downgrades
+  choco install -y python
   python -m pip install --upgrade pip
+  PATH="/c/Python37:/c/Python37/Scripts:$PATH"
 fi
 
 # Check Python and pip version

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -5,9 +5,9 @@
 
 # Install Python3 on Windows
 if [ "$TRAVIS_OS_NAME" == windows ]; then
-  choco install -y python
-  python -m pip install --upgrade pip
   PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+  choco install -y python --version=3.7.5 --allow-downgrades
+  python -m pip install --upgrade pip
 fi
 
 # Check Python and pip version

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,10 +1,10 @@
 # Check Python and pip version
-python3 --version
+python --version
 pip --version
 
 # Create virtual environment
-python3 -m pip install --upgrade virtualenv
-virtualenv -p python3 --system-site-packages $HOME/testenv
+python -m pip install --upgrade virtualenv
+virtualenv -p python --system-site-packages $HOME/testenv
 source $HOME/testenv/bin/activate
 
 # Install package with pip

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -23,7 +23,7 @@ if [[ "$TRAVIS_OS_NAME" =~ ^(linux|osx)$ ]]; then
   python3 -m pip3 install --upgrade virtualenv
   virtualenv -p python3 --system-site-packages $HOME/testenv
 else # windows
-  python -m pip3 install --upgrade virtualenv
+  python -m pip install --upgrade virtualenv
   virtualenv -p python --system-site-packages $HOME/testenv
 fi
 source $HOME/testenv/bin/activate

--- a/ci/travis_setup_conda_linux.sh
+++ b/ci/travis_setup_conda_linux.sh
@@ -1,0 +1,4 @@
+# Install Miniconda
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p $HOME/miniconda

--- a/ci/travis_setup_conda_osx.sh
+++ b/ci/travis_setup_conda_osx.sh
@@ -1,0 +1,4 @@
+# Install Miniconda
+curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p $HOME/miniconda

--- a/ci/travis_setup_conda_windows.sh
+++ b/ci/travis_setup_conda_windows.sh
@@ -1,0 +1,6 @@
+# Source: https://github.com/cclauss/Travis-CI-Python-on-three-OSes/blob/master/conda_on_Windows.yml
+
+# Install Miniconda
+# pip needs OpenSSL
+choco install -y miniconda3 openssl.light
+PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"

--- a/ci/travis_setup_conda_windows.sh
+++ b/ci/travis_setup_conda_windows.sh
@@ -4,4 +4,3 @@
 # Install Miniconda
 # pip needs OpenSSL
 choco install -y miniconda3 openssl.light
-PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"

--- a/ci/travis_setup_conda_windows.sh
+++ b/ci/travis_setup_conda_windows.sh
@@ -1,4 +1,5 @@
-# Source: https://github.com/cclauss/Travis-CI-Python-on-three-OSes/blob/master/conda_on_Windows.yml
+# Source:
+# https://github.com/cclauss/Travis-CI-Python-on-three-OSes/blob/master/conda_on_Windows.yml
 
 # Install Miniconda
 # pip needs OpenSSL

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,8 @@ class, which has several common methods for processing of EBSD patterns, also
 inherits all relevant methods from HyperSpy's Signal2D and `Signal
 <https://hyperspy.org/hyperspy-doc/current/user_guide/tools.html>`_ classes.
 
+KikuchiPy is released under the GPL v3 license.
+
 .. toctree::
     :hidden:
     :caption: Getting started
@@ -34,7 +36,7 @@ inherits all relevant methods from HyperSpy's Signal2D and `Signal
     :hidden:
     :caption: Help & reference
 
-    develop.rst
+    Contributing <contributing.rst>
     open_datasets.rst
     changelog.rst
     cite.rst

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -8,7 +8,7 @@ Pip
 ---
 
 This installs both KikuchiPy and dependencies like HyperSpy, pyXem, and so on
-that are necessary for different functionality::
+that are necessary for different functionalities::
 
     pip install kikuchipy
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -20,4 +20,4 @@ To install KikuchiPy from source, clone the repository from `GitHub
 
     git clone https://github.com/kikuchipy/kikuchipy.git
     cd kikuchipy
-    pip install .
+    pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         'dask[array]', 'hyperspy >= 1.5.2', 'h5py', 'matplotlib', 'numpy',
         'pyxem >= 0.10', 'scikit-image', 'scikit-learn', 'scipy'],
-    tests_require=['pytest >= 3.6', 'pytest-cov'],
+    tests_require=['pytest', 'pytest-cov', 'coverage == 4.5.4'],
     extras_require={'doc': [
         'sphinx >= 1.8', 'sphinx-rtd-theme', 'sphinx-copybutton']},
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         'dask[array]', 'hyperspy >= 1.5.2', 'h5py', 'matplotlib', 'numpy',
         'pyxem >= 0.10', 'scikit-image', 'scikit-learn', 'scipy'],
-    tests_require=['pytest', 'pytest-cov'],
+    tests_require=['pytest >= 3.6', 'pytest-cov'],
     extras_require={'doc': [
         'sphinx >= 1.8', 'sphinx-rtd-theme', 'sphinx-copybutton']},
     package_data={


### PR DESCRIPTION
Minor doc changes.

So far, only Conda on Linux is tested on Travis... This PR will add installation tests on Windows and macOS, and also try to install via `pip` and not only `conda`. Will add these installations incrementally to isolate potential issues:
- [x] Windows
- [x] macOS
- [x] pip