### PR TITLE
Fix minor error in code example in visualization doc

### DIFF
--- a/doc/visualizing_patterns.rst
+++ b/doc/visualizing_patterns.rst
@@ -150,7 +150,7 @@ as a visual inspection of the indexing results:
     >>> import h5py
     >>> with h5py.File('/path/to/simulated_patterns/sim.h5', mode='r') as f:
             patterns = f['EMData/EBSD/EBSDPatterns'][()]
-    >>> s_sim = kp.signals.EBSD(patterns.reshape(s.axes_manager.shape))
+    >>> s_sim = kp.signals.EBSD(patterns.reshape(s.data.shape))
     >>> hs.plot.plot_signals([s, s_sim], navigator=s_om)
 
 .. _fig-plot-multiple-scans:


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!-- Taken from the napari project https://raw.githubusercontent.com/napari/napari/master/.github/PULL_REQUEST_TEMPLATE.md -->

### Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
Fixes code example in documentation where plotting of multiple scans side-by-side. The simulated patterns from EMsoft are reshaped from a 3D array into a 4D array of same size as the experimental patterns, however, I forgot that HyperSpy flips the (x, y) coordinates with respect to NumPy when using `s.axes_manager.shape`.
 
<!-- Tell us about your new feature, improvement, or fix! -->
Change:
```python
# Old
s_sim = kp.signals.EBSD(patterns.reshape(s.axes_manager.shape))
# New
s_sim = kp.signals.EBSD(patterns.reshape(s.data.shape))
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

### References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

### How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->

#### Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
~- [ ] I have added tests that prove my fix is effective or that my feature works~