### PR TITLE
Bump version to 0.1.2 for release on pypi

### DIFF
--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -25,4 +25,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.1.2.dev0"
+version = "0.1.2"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!-- Requirements -->
<!-- * Read the contributor guide: https://kikuchipy.readthedocs.io/en/latest/contributing.html -->
<!-- * Fill out the template. It helps the review process and is useful to summarise the PR. -->
<!-- * This template can be updated during the progression of the PR to summarise its status -->

#### Description
<!-- What does this pull request do? Why is it necessary? A few sentences and/or a bullet list. -->
Bump patch version to v0.1.2 to prepare for a new release to PyPI.

This patch release is necessary for two reasons:
1. Example data aren't included in v0.1.1 when installing from source distritbuion from PyPI
2. The HyperSpy extension YAML file isn't included either

This should now be fixed both in the `master` and `v0.1.x` branches.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)