### PR TITLE
Add v0.1.2 release notes to changelog (#127)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.1.2 (2020-01-09)
+==================
+
+KikuchiPy is an open-source Python library for processing and analysis of
+electron backscatter diffraction patterns: https://kikuchipy.readthedocs.io
+
+This is a bug-fix release that ensures, unlike the previous bug-fix release,
+that necessary files are downloaded when installing from PyPI.
+
 0.1.1 (2020-01-04)
 ==================
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!-- Requirements -->
<!-- * Read the contributor guide: https://kikuchipy.readthedocs.io/en/latest/contributing.html -->
<!-- * Fill out the template. It helps the review process and is useful to summarise the PR. -->
<!-- * This template can be updated during the progression of the PR to summarise its status -->

#### Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- A few sentences and/or a bullet list. -->
Update `changelog.rst` with v0.1.2 release notes.

In future, I think we should update `changelog.rst` on master first, as I believe scikit-image does (https://github.com/scikit-image/scikit-image/blob/master/RELEASE.txt#L71).

#### How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Built docs locally with the release notes looking good