### PR TITLE
Set data type to 32-bit float for background corrections

### DIFF
--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -423,7 +423,7 @@ class EBSD(Signal2D):
                 f"Pattern {pat_shape} and static background {bg_shape} shapes "
                 "are not identical."
             )
-        dtype = np.int16
+        dtype = np.float32
         static_bg = static_bg.astype(dtype)
 
         # Get min./max. input patterns intensity after correction
@@ -494,7 +494,7 @@ class EBSD(Signal2D):
         """
 
         dtype_out = self.data.dtype.type
-        dtype = np.int16
+        dtype = np.float32
 
         # Create dask array of signal patterns and do processing on this
         dask_array = kp.util.dask._get_dask_array(signal=self, dtype=dtype)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!-- Requirements -->
<!-- * Read the contributor guide: https://kikuchipy.readthedocs.io/en/latest/contributing.html -->
<!-- * Fill out the template. It helps the review process and is useful to summarise the PR. -->
<!-- * This template can be updated during the progression of the PR to summarise its status -->

#### Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- A few sentences and/or a bullet list. -->
Fixes #135.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

#### Progress
- [x] Set data types to 32-bit float
- [x] Ready for review!

#### How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] All previous tests run fine (which highlights that patterns of different intensity distributions should be included in the test suite...)

#### Minimal example of the bug fix or new feature
<!-- Note that this example can be useful to update the user guide with! -->

```python
>>> import kikuchipy as kp
>>> s = kp.load('/some/data-with-such-an-intensity-distribution.h5')
>>> s.static_background_correction(operation='divide', relative=True)
>>> s.plot()  # Shows that intensities have been clipped
```