### PR TITLE
Fix excessive memory usage in neighbour pattern averaging

### DIFF
--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -790,9 +790,6 @@ class EBSD(Signal2D):
                 "therefore performed."
             )
 
-        # Create dask array of signal patterns and do processing on this
-        dask_array = kp.util.dask._get_dask_array(signal=self, dtype=np.float32)
-
         # Get sum of kernel coefficients for each pattern, to normalize with
         # after correlation
         nav_shape = self.axes_manager.navigation_shape
@@ -808,6 +805,9 @@ class EBSD(Signal2D):
         # Add signal dimensions to kernel array to enable its use with Dask's
         # map_blocks()
         averaging_kernel._add_axes(self.axes_manager.signal_dimension)
+
+        # Create dask array of signal patterns and do processing on this
+        dask_array = kp.util.dask._get_dask_array(signal=self)
 
         # Add signal dimensions to array be able to use with Dask's map_blocks()
         nav_dim = self.axes_manager.navigation_dimension

--- a/kikuchipy/util/experimental.py
+++ b/kikuchipy/util/experimental.py
@@ -284,7 +284,7 @@ def _average_neighbour_patterns_chunk(
 
     # Correlate patterns with kernel
     correlated_patterns = correlate(
-        patterns, weights=kernel, mode="constant", cval=0,
+        patterns.astype(np.float32), weights=kernel, mode="constant", cval=0,
     )
 
     # Divide convolved patterns by number of neighbours averaged with


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!-- Requirements -->
<!-- * Read the contributor guide: https://kikuchipy.readthedocs.io/en/latest/contributing.html -->
<!-- * Fill out the template. It helps the review process and is useful to summarise the PR. -->
<!-- * This template can be updated during the progression of the PR to summarise its status -->

#### Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- A few sentences and/or a bullet list. -->

Fixes the excessive memory use introduced in #155, by not setting the dask array to operate on to 32-bit precision.

Also relates to #154.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

#### How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Does not fill up memory when averaging a 8-bit 4,8 GB data set at 32-bit
- [x] All tests pass