### PR TITLE
Update rtd to use 3.8, remove setuptools

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -54,6 +54,8 @@ Changed
 
 Fixed
 -----
+- RtD builds documentation with Python 3.8 (fixed problem of missing .egg
+  leading build to fail).
 - Chunking of static background pattern.
 - Chunking of patterns in the h5ebsd reader.
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -14,10 +14,8 @@ formats: all
 
 # Python environment for building the docs
 python:
-  version: 3.7
+  version: 3.8
   install:
-    - method: setuptools
-      path: .
     - method: pip
       path: .
       extra_requirements:


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!-- Requirements -->
<!-- * Read the contributor guide: https://kikuchipy.readthedocs.io/en/latest/contributing.html -->
<!-- * Fill out the template. It helps the review process and is useful to summarise the PR. -->
<!-- * This template can be updated during the progression of the PR to summarise its status -->

#### Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- A few sentences and/or a bullet list. -->

Updates Python version used by Read the Docs to build the documentation from 3.7 to 3.8, and remove setuptools step (don't know what we used that in the first place).

This fixes the the doc build failing with the error:

```
/home/docs/checkouts/readthedocs.org/user_builds/kikuchipy/envs/fix-doc-build/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .[doc]
[...]
FileNotFoundError: [Errno 2] No such file or directory: '/home/docs/checkouts/readthedocs.org/user_builds/kikuchipy/envs/fix-doc-build/lib/python3.7/site-packages/kikuchipy-0.2.dev0-py3.7.egg'
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix

#### Progress
- [x] Updated 
- [x] Added change to changelog

#### How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Doc builds pass from branch `fix-doc-build` (https://readthedocs.org/projects/kikuchipy/builds/10979773/)