### PR TITLE
Correct license classifier to GPLv3+

### DIFF
--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -19,7 +19,7 @@
 author = "kikuchipy developers"
 copyright = "Copyright 2019-2020, kikuchipy"
 credits = ["Håkon Wiik Ånes", "Tina Bergh"]
-license = "GPLv3"
+license = "GPLv3+"
 maintainer = "Håkon Wiik Ånes"
 maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

The license classifier used in `setup.py` and `kikuchipy/release.py` was `GPLv3`. However, we actually have the `GPLv3+` license (https://spdx.org/licenses/GPL-3.0-or-later.html). We use this classifier in `conda-forge`, and should use it here. This is also a valid classifier on pypi (https://pypi.org/classifiers/).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

<!-- For detailed information on these and other aspects see -->
<!-- the kikuchipy contribution guidelines. -->
<!-- https://kikuchipy.readthedocs.io/en/latest/contributing.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
