### PR TITLE
Fix read/write specification for EMsoft's EBSD MP HDF5 file

### DIFF
--- a/doc/load_save_patterns.rst
+++ b/doc/load_save_patterns.rst
@@ -236,7 +236,7 @@ Currently, kikuchipy has readers and writers for the following file formats:
     +---------------------------------+------+-------+
     | NORDIF binary                   | Yes  | Yes   |
     +---------------------------------+------+-------+
-    | EMsoft EBSD master pattern HDF5 | Yes  | Yes   |
+    | EMsoft EBSD master pattern HDF5 | Yes  | No    |
     +---------------------------------+------+-------+
 
 .. note::


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Update read/write specification in documentation for EMsoft's master pattern HDF5 file (we cannot write patterns to this format).