### PR TITLE
Simplify readme, update related projects, add project URLs to setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,44 +28,34 @@
     :target: https://doi.org/10.5281/zenodo.3597646
     :alt: DOI
 
-*kikuchipy is an open-source Python library for processing and analysis of
-electron backscatter diffraction (EBSD) patterns.*
+kikuchipy is an open-source Python library for processing and analysis of
+electron backscatter diffraction (EBSD) patterns.
 
 The library builds on the tools for multi-dimensional data analysis provided
-by the `HyperSpy <https://hyperspy.org>`_ library. This means that the EBSD
-class, which has several common methods for processing of EBSD patterns, also
-inherits all relevant methods from HyperSpy's Signal2D and `Signal
-<https://hyperspy.org/hyperspy-doc/current/user_guide/tools.html>`_ classes.
-
-An effort is made to keep memory usage in check and enable scalability by using
-the `Dask <https://dask.org>`_ library for pattern processing.
+by the HyperSpy library. An effort is made to keep memory usage in check and
+enable scalability by using the Dask library for pattern processing.
 
 The project is in an alpha stage, and there will likely be breaking changes with
 each release.
 
-kikuchipy is released under the GPL v3 license.
+kikuchipy is released under the GPLv3+ license.
 
 User guide
 ----------
-
 Installation instructions, a user guide and the full API reference is available
-via Read the Docs at https://kikuchipy.org.
+here: https://kikuchipy.org.
 
 Contributing
 ------------
-
 Everyone is welcome to contribute. Please read our `contributor guide
 <https://kikuchipy.org/en/latest/contributing.html>`_ to get started!
 
 Code of Conduct
 ---------------
-
 kikuchipy has a `Code of Conduct
 <https://kikuchipy.org/en/latest/code_of_conduct.html>`_ that should be honoured
 by everyone who participates in the kikuchipy community.
 
 Cite
 ----
-
-If analysis using kikuchipy forms a part of published work, please consider
-recognizing the code development by citing the DOI above.
+If you find this project useful, please cite the DOI above.

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -5,15 +5,16 @@ Related projects
 This is a non-exhaustive list of related, open-source projects for analysis of
 EBSD data that users of kikuchipy might find useful:
 
+- `HyperSpy <https://hyperspy.org>`_: Python library with tools for
+  multi-dimensional data analysis, which kikuchipy builds upon.
 - `EMsoft <http://vbff.materials.cmu.edu/EMsoft>`_: Series of Fortran programs
   which, among numerous other tasks, can perform dictionary indexing of EBSD and
   Transmission Kikuchi Diffraction (TKD) patterns.
-- `pyxem <https://github.com/pyxem/pyxem>`_: Open-source Python library for
+- `pyxem <https://github.com/pyxem/pyxem>`_: Python library for
   multi-dimensional diffraction microscopy. Detailed example Jupyter Notebooks
   are available.
-- `orix <https://github.com/pyxem/orix>`_: Open-source Python library for
-  handling crystal orientation mapping data. Detailed example Jupyter Notebooks
-  are available.
+- `orix <https://github.com/pyxem/orix>`_: Python library for handling crystal
+  orientation mapping data. Detailed example Jupyter Notebooks are available.
 - `MTEX <https://mtex-toolbox.github.io/>`_: Matlab toolbox for analyzing and
   modeling crystallographic textures by means of EBSD or pole figure data.
 - `AstroEBSD <https://github.com/benjaminbritton/AstroEBSD>`_: Matlab package

--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,11 @@ setup(
     name=NAME,
     version=VERSION,
     license=LICENSE,
-    url="https://kikuchipy.readthedocs.io",
+    url="https://kikuchipy.org",
     python_requires=">=3.7",
     description=(
-        "Processing of electron backscatter diffraction (EBSD) patterns"
+        "Processing and analysis of electron backscatter diffraction (EBSD) "
+        "patterns."
     ),
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
@@ -100,8 +101,14 @@ setup(
     # Contact
     author=AUTHOR,
     author_email=MAINTAINER_EMAIL,
+    download_url="https://pypi.python.org/pypi/kikuchipy",
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,
+    project_urls={
+        "Bug Tracker": "https://github.com/kikuchipy/kikuchipy/issues",
+        "Documentation": "https://kikuchipy.org",
+        "Source Code": "https://github.com/kikuchipy/kikuchipy",
+    },
     # Dependencies
     # Update in .travis.yml if this list is updated!
     extras_require=extra_feature_requirements,


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Simpliy the readme, add HyperSpy to the top of the list of related projects in the docs, add project URLs to setup.py to show up on PyPI.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

<!-- For detailed information on these and other aspects see -->
<!-- the kikuchipy contribution guidelines. -->
<!-- https://kikuchipy.readthedocs.io/en/latest/contributing.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
