### PR TITLE
Correct input parameters in FFT filtering in doc

### DIFF
--- a/doc/pattern_processing.rst
+++ b/doc/pattern_processing.rst
@@ -415,8 +415,18 @@ particular functions are readily available via
 .. code-block::
 
     >>> pattern_shape = s.axes_manager.signal_shape[::-1]
-    >>> w_low = kp.filters.Window("lowpass", c=22, w_c=10, shape=pattern_shape)
-    >>> w_high = kp.filters.Window("highpass", c=3, w_c=2, shape=pattern_shape)
+    >>> w_low = kp.filters.Window(
+    ...     "lowpass",
+    ...     cutoff=22,
+    ...     cutoff_width=10,
+    ...     shape=pattern_shape
+    ... )
+    >>> w_high = kp.filters.Window(
+    ...     "highpass",
+    ...     cutoff=3,
+    ...     cutoff_width=2,
+    ...     shape=pattern_shape
+    ... )
     >>> w = w_low * w_high
     >>> import matplotlib.pyplot as plt
     >>> plt.imshow(w)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Change incorrect input parameters in FFT filtering doc (`pattern_processing.rst`) from `c` and `w_c` to `cutoff` and `cutoff_width`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

<!-- For detailed information on these and other aspects see -->
<!-- the kikuchipy contribution guidelines. -->
<!-- https://kikuchipy.readthedocs.io/en/latest/contributing.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
