### PR TITLE
Add NotImplementedError to RGB VirtualBSEImage rescale/normalize

### DIFF
--- a/doc/feature_maps.rst
+++ b/doc/feature_maps.rst
@@ -30,7 +30,7 @@ Following the notation in [Marquardt2017]_, it is given by
 The function :math:`w(h, k)` is the Fast Fourier Transform (FFT) power spectrum
 of the EBSD pattern, and the vectors :math:`\mathbf{q}` are the frequency
 vectors with components :math:`(h, k)`. The sharper the Kikuchi bands, the
-higher the high frequency content of the power spectrum, and thus the closer
+greater the high frequency content of the power spectrum, and thus the closer
 :math:`Q` will be to unity. To visualize parts of the computation, we compute
 the power spectrum of a pattern in an :class:`~kikuchipy.signals.EBSD` object
 ``s`` and the frequency vectors, shift the zero-frequency components to the

--- a/doc/virtual_backscatter_electron_imaging.rst
+++ b/doc/virtual_backscatter_electron_imaging.rst
@@ -60,7 +60,7 @@ Sometimes we want to get many images from parts of the detector, e.g. like what
 is demonstrated in the `xcdskd project
 <https://xcdskd.readthedocs.io/en/latest/bse_imaging.html>`_ with the angle
 resolved virtual backscatter electron array (arbse/vbse array). Instead of
-keeping control of multiple :class:`hyperspy.roi.BaseInteractiveROI` objects, we
+keeping track of multiple :class:`hyperspy.roi.BaseInteractiveROI` objects, we
 can create a detector grid of a certain shape, e.g. (5, 5), and obtain gray
 scale images, or combine multiple grid tiles in red, green and channels to
 obtain RGB images.

--- a/kikuchipy/signals/_common_image.py
+++ b/kikuchipy/signals/_common_image.py
@@ -21,6 +21,7 @@ from typing import Union, Tuple, Optional
 
 from dask.diagnostics import ProgressBar
 from hyperspy._signals.signal2d import Signal2D
+from hyperspy.misc.rgb_tools import rgb_dtypes
 import numpy as np
 from skimage.util.dtype import dtype_range
 
@@ -113,10 +114,20 @@ class CommonImage(Signal2D):
 
         >>> s.rescale_intensity(percentiles=(1, 99))
 
-        Here, the darkest and brighets within the 1% percentile are set
-        to the ends of the data type range, e.g. 0 and 255 respectively
-        for images of ``uint8`` data type.
+        Here, the darkest and brightest pixels within the 1% percentile
+        are set to the ends of the data type range, e.g. 0 and 255
+        respectively for images of ``uint8`` data type.
+
+        Notes
+        -----
+        Rescaling RGB images is not possible. Use RGB channel
+        normalization when creating the image instead.
         """
+        if self.data.dtype in rgb_dtypes.values():
+            raise NotImplementedError(
+                "Use RGB channel normalization when creating the image instead."
+            )
+
         # Determine min./max. intensity of input image to rescale to
         if in_range is not None and percentiles is not None:
             raise ValueError(
@@ -195,7 +206,17 @@ class CommonImage(Signal2D):
         >>> s.normalize_intensity()
         >>> np.mean(s.data)
         2.6373216e-08
+
+        Notes
+        -----
+        Rescaling RGB images is not possible. Use RGB channel
+        normalization when creating the image instead.
         """
+        if self.data.dtype in rgb_dtypes.values():
+            raise NotImplementedError(
+                "Use RGB channel normalization when creating the image instead."
+            )
+
         if dtype_out is None:
             dtype_out = self.data.dtype
 

--- a/kikuchipy/signals/tests/test_virtual_bse_image.py
+++ b/kikuchipy/signals/tests/test_virtual_bse_image.py
@@ -15,3 +15,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from kikuchipy.generators import VirtualBSEGenerator
+
+
+class TestVirtualBSEImage:
+    def test_rescale_rgb_raises(self, dummy_signal):
+        vbse_gen = VirtualBSEGenerator(dummy_signal)
+        vbse_gen.grid_shape = (3, 3)
+        rgb = vbse_gen.get_rgb_image(r=(0, 0), g=(0, 1), b=(1, 0))
+        with pytest.raises(NotImplementedError):
+            rgb.rescale_intensity()
+
+    def test_normalize_rgb_raises(self, dummy_signal):
+        vbse_gen = VirtualBSEGenerator(dummy_signal)
+        vbse_gen.grid_shape = (3, 3)
+        rgb = vbse_gen.get_rgb_image(r=(0, 0), g=(0, 1), b=(1, 0))
+        with pytest.raises(NotImplementedError):
+            rgb.normalize_intensity()

--- a/kikuchipy/signals/virtual_bse_image.py
+++ b/kikuchipy/signals/virtual_bse_image.py
@@ -17,7 +17,6 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from hyperspy._signals.signal2d import Signal2D
-import numpy as np
 
 from kikuchipy.signals._common_image import CommonImage
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Raise `NotImplementedError` when trying to call `rescale_intensity()` and `normalize_intensity()` on a `VirtualBSEImage` object with a HyperSpy RGB data type.

Also improve some doc wording.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

<!-- For detailed information on these and other aspects see -->
<!-- the kikuchipy contribution guidelines. -->
<!-- https://kikuchipy.readthedocs.io/en/latest/contributing.html -->

#### Minimal example of the bug fix or new feature
<!-- Note that this example can be useful to update the user guide with! -->

```python
>>> import kikuchipy as kp
>>> import numpy as np
>>> s = kp.signals.EBSD(np.zeros((10, 10, 10, 10)))
>>> vbse_gen = kp.generators.VirtualBSEGenerator(s)
>>> rgb = vbse_gen.get_rgb_image(r=(0, 0), g=(0, 1), b=(0, 2))
>>> rgb.rescale_intensity()
[...]
    raise NotImplementedError(
NotImplementedError: Use RGB channel normalization when creating the image instead.
```

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
