### PR TITLE
Use numpy.fft instead of scipy.fft

### DIFF
--- a/doc/_static/image/doc_feature_maps_images.py
+++ b/doc/_static/image/doc_feature_maps_images.py
@@ -23,7 +23,7 @@ import matplotlib
 matplotlib.rcParams["backend"] = "qt5agg"
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy
+from numpy.fft import fftshift
 
 import kikuchipy as kp
 
@@ -75,7 +75,7 @@ plt.savefig(
 # Frequency vectors
 q = kp.util.pattern.fft_frequency_vectors(shape=p.shape)
 plt.figure()
-plt.imshow(scipy.fft.fftshift(q))
+plt.imshow(fftshift(q))
 plt.colorbar()
 plt.savefig(
     os.path.join(featdir, "fft_frequency_vectors.png"),

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,14 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 Contributors to each release are listed in alphabetical order.
 
+Unreleased
+==========
+
+Changed
+-------
+- Use numpy.fft instead of scipy.fft because HyperSpy requires scipy < 1.4 on
+  conda-forge, while scipy.fft was introduced in scipy 1.4.
+
 0.2.0 (2020-05-19)
 ==================
 

--- a/doc/feature_maps.rst
+++ b/doc/feature_maps.rst
@@ -40,7 +40,7 @@ centre, and plot them:
 
     >>> import kikuchipy as kp
     >>> import matplotlib.pyplot as plt
-    >>> import scipy
+    >>> import numpy as np
 
     >>> p = s.inav[0, 0].data
     >>> plt.figure()
@@ -54,7 +54,7 @@ centre, and plot them:
 
     >>> q = kp.util.pattern.fft_frequency_vectors(shape=p.shape)
     >>> plt.figure()
-    >>> plt.imshow(scipy.fft.fftshift(q))
+    >>> plt.imshow(np.fft.fftshift(q))
     >>> plt.colorbar()
 
 .. _fig-image-quality-pattern:

--- a/kikuchipy/filters/fft_barnes.py
+++ b/kikuchipy/filters/fft_barnes.py
@@ -24,7 +24,10 @@ via FFT written by Connelly Barnes (public domain, 2007).
 from typing import Union, Tuple, List
 
 import numpy as np
-from scipy.fft import next_fast_len, rfft2, irfft2
+from numpy.fft import rfft2, irfft2
+from scipy.fftpack import next_fast_len
+
+# from scipy.fft import next_fast_len, rfft2, irfft2
 
 from kikuchipy.filters.window import Window
 
@@ -35,10 +38,14 @@ def _fft_filter_setup(
     window_shape = window.shape
 
     # Optimal FFT shape
-    real_fft_only = True
+    #    real_fft_only = True
     fft_shape = (
-        next_fast_len(image_shape[0] + window_shape[0] - 1, real_fft_only),
-        next_fast_len(image_shape[1] + window_shape[1] - 1, real_fft_only),
+        next_fast_len(
+            image_shape[0] + window_shape[0] - 1
+        ),  # , real_fft_only),
+        next_fast_len(
+            image_shape[1] + window_shape[1] - 1
+        ),  # , real_fft_only),
     )
 
     # Pad window to optimal FFT size

--- a/kikuchipy/pattern/_pattern.py
+++ b/kikuchipy/pattern/_pattern.py
@@ -27,7 +27,7 @@ from typing import Union, Tuple, Optional, List
 
 from numba import njit
 import numpy as np
-from scipy.fft import (
+from numpy.fft import (
     fft2,
     rfft2,
     ifft2,

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -25,4 +25,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.2.0"
+version = "0.2.dev1"

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     # Update in .travis.yml if this list is updated!
     extras_require=extra_feature_requirements,
     install_requires=[
-        "dask >= 2.14",
+        "dask[array] >= 2.14",
         "hyperspy >= 1.5.2",
         "h5py >= 2.10",
         "matplotlib >= 3.2",

--- a/setup.py
+++ b/setup.py
@@ -113,14 +113,15 @@ setup(
     # Update in .travis.yml if this list is updated!
     extras_require=extra_feature_requirements,
     install_requires=[
-        "dask[array] >= 2.14",
-        "hyperspy[learning] >= 1.5.2",
+        "dask >= 2.14",
+        "hyperspy >= 1.5.2",
         "h5py >= 2.10",
         "matplotlib >= 3.2",
         "numpy >= 1.18",
         "numba >= 0.48",
         "scikit-image >= 0.16, < 0.17",
-        "scipy >= 1.4",
+        "scikit-learn",
+        "scipy",
     ],
     entry_points={"hyperspy.extensions": "kikuchipy = kikuchipy"},
     # Files to include when distributing package


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Tries to fix #179. HyperSpy requires scipy < 1.4 on conda-forge. We started using scipy.fft in v0.2.0 for FFT filtering, but that was introduced in scipy 1.4. Have therefore removed scipy > 1.4 requirement in setup.py and started switched to numpy.fft until HyperSpy removes scipy < 1.4 requirement on conda-forge.

This might affect some of the routines using FFT (image quality calculation, FFT filtering, dynamic background correction, getting the dynamic background).

Also stopped using selectors (dask[array], hyperspy[learning]) and reintroduced scikit-learn as a dependency.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

<!-- For detailed information on these and other aspects see -->
<!-- the kikuchipy contribution guidelines. -->
<!-- https://kikuchipy.readthedocs.io/en/latest/contributing.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
