### PR TITLE
Prepare for v0.2.2 release

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,8 +11,11 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 Contributors to each release are listed in alphabetical order.
 
-Unreleased
-==========
+0.2.2 (2020-05-24)
+==================
+
+This is a patch release that fixes reading of EBSD data sets from h5ebsd files
+with arbitrary scan group names.
 
 Contributors
 ------------

--- a/doc/load_save_data.rst
+++ b/doc/load_save_data.rst
@@ -276,9 +276,9 @@ passed. The ``scan_group_names`` parameter is unnecessary if only ``Scan 1`` is
 to be read since reading the first scan in the file is the default behaviour.
 
 So far, only :ref:`saving patterns <save-patterns>` to kikuchipy's own h5ebsd
-format is supported. It is possible to write a new scan with a new scan number
-to an existing, but closed, h5ebsd file in the kikuchipy format, e.g. one
-containing only ``Scan 1``, by passing:
+format is supported. It is possible to write a new scan with a scan name
+``Scan x``, where ``x`` is a number, to an existing, but closed, h5ebsd file in
+the kikuchipy format, e.g. one containing only ``Scan 1``, by passing:
 
 .. code-block::
 

--- a/kikuchipy/io/plugins/h5ebsd.py
+++ b/kikuchipy/io/plugins/h5ebsd.py
@@ -86,7 +86,7 @@ def file_reader(
         until required. Allows opening arbitrary sized datasets. Default
         is False.
     kwargs
-        Key word arguments passed to h5py.File.
+        Key word arguments passed to :obj:`h5py:File`.
 
     Returns
     -------
@@ -166,7 +166,7 @@ def get_scan_groups(file: h5py.File) -> List[h5py.Group]:
 
     Parameters
     ----------
-    file : h5py:file
+    file : h5py:File
         File where manufacturer, version and scan datasets should reside
         in the top group.
 
@@ -228,7 +228,7 @@ def get_desired_scan_groups(
 
     Parameters
     ----------
-    file: h5py:File
+    file : h5py:File
         File where manufacturer, version and scan datasets should
         reside in the top group.
     scan_group_names
@@ -485,7 +485,7 @@ def h5ebsdheader2dicts(
     elif "bruker" in manufacturer.lower():
         md, omd, scan_size = brukerheader2dicts(scan_group, md)
     else:  # kikuchipy
-        md, omd, scan_size = kikuchipyheader2dicts(scan_group, md, lazy)
+        md, omd, scan_size = kikuchipyheader2dicts(scan_group, md)
 
     ebsd_node = metadata_nodes("ebsd")
     md.set_item(ebsd_node + ".manufacturer", manufacturer)
@@ -495,7 +495,7 @@ def h5ebsdheader2dicts(
 
 
 def kikuchipyheader2dicts(
-    scan_group: h5py.Group, md: DictionaryTreeBrowser, lazy: bool = False
+    scan_group: h5py.Group, md: DictionaryTreeBrowser
 ) -> Tuple[DictionaryTreeBrowser, DictionaryTreeBrowser, DictionaryTreeBrowser]:
     """Return scan metadata dictionaries from a kikuchipy h5ebsd file.
 
@@ -505,8 +505,6 @@ def kikuchipyheader2dicts(
         HDF group of scan data and header.
     md
         Dictionary with empty fields from kikuchipy's metadata.
-    lazy
-        Read dataset lazily.
 
     Returns
     -------
@@ -758,7 +756,7 @@ def file_writer(
     scan_number
         Scan number in name of HDF dataset when writing to an existing,
         but not open, h5ebsd file.
-    **kwargs :
+    kwargs
         Keyword arguments passed to :meth:`h5py:Group.require_dataset`.
     """
     # Set manufacturer and version to use in file
@@ -877,7 +875,7 @@ def dict2h5ebsdgroup(dictionary: dict, group: h5py.Group, **kwargs):
         ``Metadata``, with keys as dataset names.
     group : h5py:Group
         HDF group to write dictionary to.
-    **kwargs :
+    kwargs
         Keyword arguments passed to :meth:`h5py:Group.require_dataset`.
     """
     for key, val in dictionary.items():

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -25,4 +25,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.2.1"
+version = "0.2.2"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

* Prepare for `v0.2.2` release.
* Update changelog.
* Remove unused `lazy` argument to `kikuchipyheader2dicts()` in h5ebsd reader.
* Clarify on writing to h5ebsd files in user guide.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

<!-- For detailed information on these and other aspects see -->
<!-- the kikuchipy contribution guidelines. -->
<!-- https://kikuchipy.readthedocs.io/en/latest/contributing.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
