### PR TITLE
Remove language_version in pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: master
     hooks:
       - id: black
-        language_version: python3.7

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,18 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 Contributors to each release are listed in alphabetical order.
 
+Unreleased
+==========
+
+Contributors
+------------
+- Håkon Wiik Ånes
+
+Changed
+-------
+- Removed `language_version` in `pre-commit` config file.
+  (`#195 <https://github.com/kikuchipy/kikuchipy/pull/195>`_)
+
 0.2.2 (2020-05-24)
 ==================
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Trying to commit changes with Python 3.8 when `language_version: python3.7` in pre-commit config file failed. Since we support both 3.7 and 3.8, this is removed.

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
