### PR TITLE
Allow scikit-image >= 0.16, fix related adaptive histogram test

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,7 +20,9 @@ Contributors
 
 Changed
 -------
-- Removed `language_version` in `pre-commit` config file.
+- Allow scikit-image >= 0.16.
+  (`#196 <https://github.com/kikuchipy/kikuchipy/pull/196>`_)
+- Removed language_version in pre-commit config file.
   (`#195 <https://github.com/kikuchipy/kikuchipy/pull/195>`_)
 
 0.2.2 (2020-05-24)

--- a/kikuchipy/pattern/tests/test_chunk.py
+++ b/kikuchipy/pattern/tests/test_chunk.py
@@ -20,6 +20,7 @@ import dask.array as da
 import numpy as np
 import pytest
 from scipy.ndimage import convolve, gaussian_filter
+from skimage import __version__ as skimage_version
 from skimage.util.dtype import dtype_range
 
 from kikuchipy.filters.fft_barnes import _fft_filter
@@ -76,9 +77,15 @@ DYN_CORR_UINT16_SPATIAL_STD2 = np.array(
 DYN_CORR_UINT8_SPATIAL_STD2_OMAX250 = np.array(
     [[167, 210, 177], [250, 217, 184], [217, 31, 0]], dtype=np.uint8,
 )
-ADAPT_EQ_UINT8 = np.array(
+ADAPT_EQ_UINT8_SKIMAGE16 = np.array(
     [[127, 223, 127], [255, 223, 31], [223, 31, 0]], dtype=np.uint8
 )
+ADAPT_EQ_UINT8_SKIMAGE17 = np.array(
+    [[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8
+)
+ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE16
+if skimage_version[2:4] == str(17):
+    ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE17
 
 
 class TestRescaleIntensityChunk:

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "matplotlib >= 3.2",
         "numpy >= 1.18",
         "numba >= 0.48",
-        "scikit-image >= 0.16, < 0.17",
+        "scikit-image >= 0.16",
         "scikit-learn",
         "scipy",
     ],


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

The test `kikuchipy/pattern/tests/test_chunk.py::TestAdaptiveHistogramEqualizationChunk::test_adaptive_histogram_equalization_chunk` failed with scikit-image 0.17.2, while passed for 0.16.2.

This PR:
* Allow scikit-image >= 0.16 in setup.py
* Ensure mentioned test pass for both scikit-image versions 0.16 and 0.17. This fix leads to a coverage reduction of one line when running the test suite with scikit-image 0.16... But that is acceptable.

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
