### PR TITLE
Fix EDAX-Bruker (PCy, PCz) conversion for rectangular detectors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -148,6 +148,9 @@ Removed
 
 Fixed
 -----
+- Conversion from EDAX TSL projection center (PC) convention for (PCy, PCz) for
+  rectangular detectors are corrected.
+  (`#604 <https://github.com/pyxem/kikuchipy/pull/604>`_)
 - Default ``EBSD.detector.shape`` is now correct when a detector is not passed upon
   initialization. (`#603 <https://github.com/pyxem/kikuchipy/pull/603>`_)
 - Oxford Instruments .ebsp files of version 4 can now be read.


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR changes the EDAX->Bruker (PCy, PCz) conversion for rectangular detectors. The correct conversion is as follows:

PCy = 1 - y*/Ny
PCz = z* / min(Nx, Ny)

where (PCy, PCz) are the Bruker projection center (PC) y and z coordinates, (Nx, Ny) are the number of detector columns and rows, and (y*, z*) are the EDAX TSL PC y and z coordinates.

The Oxford->Bruker conversion stays the same.

This change follows the same change coming in a new version of PyEBSDIndex (relevant commit https://github.com/drowenhorst-nrl/PyEBSDIndex/commit/ea22dfd3c2c8f7de60d4d3750db1a85ec1be1369). Hence, we should wait to merge this until a new version of PyEBSDIndex is available with this change.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)
- [ ] Wait for a new version of PyEBSDIndex

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
