### PR TITLE
Mark some refinement tests flaky

### DIFF
--- a/tests/test_indexing/test_ebsd_refinement.py
+++ b/tests/test_indexing/test_ebsd_refinement.py
@@ -420,6 +420,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
         assert xmap_ref.shape == xmap.shape
         assert not np.allclose(xmap_ref.rotations.data, xmap.rotations.data)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.parametrize(
         (
             "ebsd_with_axes_and_random_data, detector, method, initial_step, rtol, "
@@ -480,6 +481,8 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
             maxeval=maxeval,
         )
         assert xmap_ref.shape == xmap.shape
+
+        # Rotations have been refined (changed, at least)
         assert not np.allclose(xmap_ref.rotations.data, xmap.rotations.data)
 
     def test_refine_orientation_not_compute(
@@ -909,6 +912,7 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
         if maxeval:
             assert num_evals_ref.max() == maxeval
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.parametrize(
         "method, method_kwargs",
         [
@@ -987,6 +991,7 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
 
 
 class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.parametrize(
         "method_kwargs, trust_region",
         [


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Tests reported as flaky in #750 are allowed to rerun three times.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
