### PR TITLE
Prepare for 0.11.5 patch release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      
+
       - uses: isort/isort-action@master
         with:
           configuration: --profile black --filter-files --force-sort-within-sections --check-only --diff
@@ -49,7 +49,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: '3.10'
-            DEPENDENCIES: dask==2021.8.1 diffsims==0.5.2 hyperspy>=2 matplotlib==3.5 numba==0.57 numpy==1.23.0 orix==0.12.1 pooch==1.3.0 pyebsdindex==0.2.0 scikit-image==0.21.0
+            DEPENDENCIES: dask==2021.8.1 diffsims==0.5.2 hyperspy>=2.2 matplotlib==3.6 numba==0.57 numpy==1.23.0 orix==0.12.1 pooch==1.3.0 pyebsdindex==0.3.9.2 scikit-image==0.21.0
             LABEL: -oldest
           - os: ubuntu-latest
             python-version: '3.12'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,18 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
+0.11.5 (2026-03-08)
+===================
+
+Added
+-----
+- Add lower version restriction for optional dependency PyEBSDIndex >= 0.3.9.2.
+
+Removed
+-------
+- Remove upper version restriction for NumPy.
+
+
 0.11.4 (2026-03-04)
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,11 @@ were listed in alphabetical order by first name until version 0.7.0.
 
 Added
 -----
-- Add lower version restriction for optional dependency PyEBSDIndex >= 0.3.9.2.
+- Add lower version restriction for optional dependency PyEBSDIndex to 0.3.9.2.
+
+Changed
+-------
+- Increased lower version restriction for Matplotlib to 3.6.
 
 Removed
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "h5py             >= 2.10",
     "imageio",
     "lazy_loader",
-    "matplotlib       >= 3.5",
+    "matplotlib       >= 3.6",
     "numba            >= 0.57",
     "numpy            >= 1.23.0",
     "orix             >= 0.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ dependencies = [
     "lazy_loader",
     "matplotlib       >= 3.5",
     "numba            >= 0.57",
-    # TODO: Remove upper restriction once a release for the following
-    # issue is made: https://github.com/USNavalResearchLaboratory/PyEBSDIndex/issues/77
-    "numpy            >= 1.23.0, < 2.4",
+    "numpy            >= 1.23.0",
     "orix             >= 0.12.1",
     "packaging",
     "pooch            >= 1.3.0",
@@ -65,7 +63,7 @@ dependencies = [
 [project.optional-dependencies]
 all = [
     "nlopt",
-    "pyebsdindex                  >= 0.2, != 0.3.1",
+    "pyebsdindex                  >= 0.3.9.2",
     "pyvista",
 ]
 doc = [

--- a/src/kikuchipy/__init__.py
+++ b/src/kikuchipy/__init__.py
@@ -31,7 +31,7 @@ credits = [
     "Carter Francis",
     "Magnus Nord",
 ]
-__version__ = "0.11.4"
+__version__ = "0.11.5"
 
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR addresses #777 by changing the following version limits:
- Removing upper limit on NumPy
- Requiring PyEBSDIndex >= 0.3.9.2
- Increase minimal Matplotlib from 3.5 to 3.6 (3.5 was incorrectly allowed before)

Python 3.10 is still supported.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
