### PR TITLE
Interactive EBSD detector plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dask-worker-space
 
 # Other
 .scratch/
+
+# uv
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2019-2025 the kikuchipy developers
+## Copyright 2019-2026 the kikuchipy developers
 ##
 ## This file is part of kikuchipy.
 ##
@@ -16,6 +16,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 ##
+
 repos:
   # https://docs.astral.sh/ruff/configuration
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Added
   (`#785 <https://github.com/pyxem/kikuchipy/pull/785>`_)
 - Dependency on typing-extensions for type hints only available from Python >= 3.11.
   (`#785 <https://github.com/pyxem/kikuchipy/pull/785>`_)
+- Optional dependency on ipywidgets and IPython for IPython widgets.
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Added
   (`#785 <https://github.com/pyxem/kikuchipy/pull/785>`_)
 - Optional dependency on ipywidgets and IPython for IPython widgets.
   (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+- Optional dependency on psygnal to allow triggering actions based on state changes.
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
 
 Changed
 -------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,6 +83,8 @@ intersphinx_mapping = {
     "hyperspy": ("https://hyperspy.org/hyperspy-doc/current", None),
     "h5py": ("https://docs.h5py.org/en/stable", None),
     "imageio": ("https://imageio.readthedocs.io/en/stable", None),
+    "IPython": ("https://ipython.readthedocs.io/en/stable", None),
+    "ipywidgets": ("https://ipywidgets.readthedocs.io/en/stable", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "numba": ("https://numba.readthedocs.io/en/latest", None),
     "numpy": ("https://numpy.org/doc/stable", None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,6 +94,7 @@ intersphinx_mapping = {
     "orix": ("https://orix.readthedocs.io/en/stable", None),
     "packaging": ("https://packaging.python.org/en/latest", None),
     "pooch": ("https://www.fatiando.org/pooch/latest", None),
+    "psygnal": ("https://psygnal.readthedocs.io/en/latest", None),
     "pyebsdindex": ("https://pyebsdindex.readthedocs.io/en/stable", None),
     "pyopencl": ("https://documen.tician.de/pyopencl", None),
     "pytest": ("https://docs.pytest.org/en/stable", None),

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -126,6 +126,8 @@ This is a list of core package dependencies:
 
 Some functionality requires optional dependencies:
 
+* :doc:`ipywidgets <ipywidgets:index>`: Interactive widgets in Jupyter notebooks.
+* :doc:`IPython <ipython:index>`: Interactive widgets in Jupyter notebooks.
 * :doc:`pyebsdindex <pyebsdindex:index>`: Hough indexing.
   We recommend to install with optional GPU support via :doc:`pyopencl<pyopencl:index>`
   with ``pip install "pyebsdindex[gpu]""`` or

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -128,6 +128,7 @@ Some functionality requires optional dependencies:
 
 * :doc:`ipywidgets <ipywidgets:index>`: Interactive widgets in Jupyter notebooks.
 * :doc:`IPython <ipython:index>`: Interactive widgets in Jupyter notebooks.
+* :doc:`psygnal <psygnal:index>`: Trigger actions based on state changes.
 * :doc:`pyebsdindex <pyebsdindex:index>`: Hough indexing.
   We recommend to install with optional GPU support via :doc:`pyopencl<pyopencl:index>`
   with ``pip install "pyebsdindex[gpu]""`` or

--- a/examples/reference_frames/visualize_detector_sample_reference_frame.py
+++ b/examples/reference_frames/visualize_detector_sample_reference_frame.py
@@ -192,4 +192,20 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
     ax.set_title(pc_string(det6))
     det6.plot_side_view(ax=ax)
 
+# %%
+# Interactive changes
+# ===================
+#
+# We can also change the sample and detector tilts and the PC values interactively.
+#
+# .. note::
+#
+#   This requires that :mod:`ipywidgets` is installed and that the code is running in
+#   an interactive environment with an interactive Matplotlib backend.
+#
+# The default behavior is not to affect the detector.
+# Here, we want the changes to affect the detector inplace.
+
+det6.plot_side_view_interactive(inplace=True)
+
 plt.show()

--- a/examples/reference_frames/visualize_detector_sample_reference_frame.py
+++ b/examples/reference_frames/visualize_detector_sample_reference_frame.py
@@ -24,8 +24,20 @@ Detector-sample geometry views
 
 This example shows how to view the detector-sample geometry using the
 :class:`~kikuchipy.detectors.EBSDDetector`.
-This can be useful when understanding the geometry and the definition of the detector
+Both a side view and top view are available.
+These can be useful when understanding the geometry and the definition of the detector
 parameters.
+
+For a more in-depth tutorial on the various reference frames in kikuchipy, see the
+:doc:`reference frames tutorial </tutorials/reference_frames>`.
+
+.. note::
+
+    The top view only shows a change in :attr:`~kikuchipy.detectors.EBSDDetector.pcx`,
+    :attr:`~kikuchipy.detectors.EBSDDetector.pcz`, and
+    :attr:`~kikuchipy.detectors.EBSDDetector.azimuthal`.
+    Changes in other parameters like the sample and detector tilts do not change the top
+    view.
 """
 
 # %%
@@ -66,17 +78,13 @@ _ = fig.suptitle(f"Default detector-sample geometry\n{tilt_string(det1)}")
 
 det2 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-fig = plt.figure(figsize=(9, 6), layout="constrained")
+fig = plt.figure(figsize=(9, 3), layout="constrained")
 for i, stilt in enumerate([0, 45, 90]):
     det2.sample_tilt = stilt
 
-    ax1 = fig.add_subplot(2, 3, i + 1)
-    ax1.set_title("Side view\n" + tilt_string(det2))
-    det2.plot_side_view(ax=ax1)
-
-    ax2 = fig.add_subplot(2, 3, i + 4)
-    ax2.set_title("Top view")
-    det2.plot_top_view(ax=ax2)
+    ax = fig.add_subplot(1, 3, i + 1)
+    ax.set_title("Side view\n" + tilt_string(det2))
+    det2.plot_side_view(ax=ax)
 
 # %%
 # Changing detector tilt
@@ -84,17 +92,13 @@ for i, stilt in enumerate([0, 45, 90]):
 
 det3 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-fig = plt.figure(figsize=(9, 6), layout="constrained")
+fig = plt.figure(figsize=(9, 3), layout="constrained")
 for i, tilt in enumerate([0, 45, 90]):
     det3.tilt = tilt
 
-    ax1 = fig.add_subplot(2, 3, i + 1)
-    ax1.set_title("Side view\n" + tilt_string(det3))
-    det3.plot_side_view(ax=ax1)
-
-    ax2 = fig.add_subplot(2, 3, i + 4)
-    ax2.set_title("Top view")
-    det3.plot_top_view(ax=ax2)
+    ax = fig.add_subplot(1, 3, i + 1)
+    ax.set_title("Side view\n" + tilt_string(det3))
+    det3.plot_side_view(ax=ax)
 
 # %%
 # Changing sample and detector tilts
@@ -108,18 +112,14 @@ det4 = kp.detectors.EBSDDetector(shape=(60, 60))
 sample_tilts = [90, 45, 0]
 detector_tilts = sample_tilts[::-1]
 
-fig = plt.figure(figsize=(9, 6), layout="constrained")
+fig = plt.figure(figsize=(9, 3), layout="constrained")
 for i, (stilt, tilt) in enumerate(zip(sample_tilts, detector_tilts)):
     det4.sample_tilt = stilt
     det4.tilt = tilt
 
-    ax1 = fig.add_subplot(2, 3, i + 1)
-    ax1.set_title("Side view\n" + tilt_string(det4))
-    det4.plot_side_view(ax=ax1)
-
-    ax2 = fig.add_subplot(2, 3, i + 4)
-    ax2.set_title("Top view")
-    det4.plot_top_view(ax=ax2)
+    ax = fig.add_subplot(1, 3, i + 1)
+    ax.set_title("Side view\n" + tilt_string(det4))
+    det4.plot_side_view(ax=ax)
 
 # %%
 # Changing projection center
@@ -156,17 +156,13 @@ for i, pcx in enumerate([0, 0.5, 1]):
 
 det6 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-fig = plt.figure(figsize=(9, 6), layout="constrained")
+fig = plt.figure(figsize=(9, 3), layout="constrained")
 for i, pcy in enumerate([0, 0.5, 1]):
     det6.pcy = pcy
 
-    ax1 = fig.add_subplot(2, 3, i + 1)
-    ax1.set_title("Side view\n" + pc_string(det6))
-    det6.plot_side_view(ax=ax1)
-
-    ax2 = fig.add_subplot(2, 3, i + 4)
-    ax2.set_title("Top view")
-    det6.plot_top_view(ax=ax2)
+    ax = fig.add_subplot(1, 3, i + 1)
+    ax.set_title("Side view\n" + pc_string(det6))
+    det6.plot_side_view(ax=ax)
 
 # %%
 # Changing PCz
@@ -203,6 +199,6 @@ for i, pcz in enumerate([0.2, 0.6, 1]):
 # Here, we want the changes to affect the detector inplace.
 
 det8 = kp.detectors.EBSDDetector(shape=(60, 60))
-_, fig = det8.plot_interactive(figsize=(9, 3), legend=True, return_figure=True)
+det8.plot_interactive(figsize=(9, 3))
 
 plt.show()

--- a/examples/reference_frames/visualize_detector_sample_reference_frame.py
+++ b/examples/reference_frames/visualize_detector_sample_reference_frame.py
@@ -37,6 +37,7 @@ parameters.
 # %%
 # Imports and some reusable functions.
 
+from IPython.display import display
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -206,6 +207,7 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 # The default behavior is not to affect the detector.
 # Here, we want the changes to affect the detector inplace.
 
-det6.plot_side_view_interactive(inplace=True)
+widgets = det6.plot_side_view(interactive=True)
+display(widgets)
 
 plt.show()

--- a/examples/reference_frames/visualize_detector_sample_reference_frame.py
+++ b/examples/reference_frames/visualize_detector_sample_reference_frame.py
@@ -37,7 +37,6 @@ parameters.
 # %%
 # Imports and some reusable functions.
 
-from IPython.display import display
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -207,7 +206,6 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 # The default behavior is not to affect the detector.
 # Here, we want the changes to affect the detector inplace.
 
-widgets = det6.plot_side_view(interactive=True)
-display(widgets)
+det6.plot_side_view(interactive=True)
 
 plt.show()

--- a/examples/reference_frames/visualize_detector_sample_reference_frame.py
+++ b/examples/reference_frames/visualize_detector_sample_reference_frame.py
@@ -18,27 +18,20 @@
 #
 
 """
-==================================
-Detector-sample geometry side-view
-==================================
+==============================
+Detector-sample geometry views
+==============================
 
 This example shows how to view the detector-sample geometry using the
 :class:`~kikuchipy.detectors.EBSDDetector`.
 This can be useful when understanding the geometry and the definition of the detector
 parameters.
-
-.. note::
-
-    This example only shows the side-view.
-    It ignores the detector :attr:`~kikuchipy.detectors.EBSDDetector.azimuthal` and
-    :attr:`~kikuchipy.detectors.EBSDDetector.twist`.
 """
 
 # %%
 # Imports and some reusable functions.
 
 import matplotlib.pyplot as plt
-import numpy as np
 
 import kikuchipy as kp
 
@@ -59,55 +52,49 @@ def pc_string(detector: kp.detectors.EBSDDetector) -> str:
 
 # %%
 # Get the default detector.
-det1 = kp.detectors.EBSDDetector()
+det1 = kp.detectors.EBSDDetector(shape=(60, 60))
 print(det1)
 
 # %%
 # And view the detector-sample geometry.
-fig = det1.plot_side_view(annotate=True, return_figure=True)
+fig = det1.plot_side_view(legend=True, return_figure=True)
 _ = fig.suptitle(f"Default detector-sample geometry\n{tilt_string(det1)}")
 
 # %%
 # Changing sample tilt
 # ====================
 
-det2 = kp.detectors.EBSDDetector()
+det2 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-sample_tilts = np.linspace(0, 90, num=9)
-nrows = 3
-ncols = int(np.ceil(sample_tilts.size / nrows))
+fig = plt.figure(figsize=(9, 6), layout="constrained")
+for i, stilt in enumerate([0, 45, 90]):
+    det2.sample_tilt = stilt
 
-fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
-for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
-    if i > sample_tilts.size - 1:
-        break
+    ax1 = fig.add_subplot(2, 3, i + 1)
+    ax1.set_title("Side view\n" + tilt_string(det2))
+    det2.plot_side_view(ax=ax1)
 
-    det2.sample_tilt = sample_tilts[i]
-
-    ax = fig.add_subplot(nrows, ncols, i + 1)
-    ax.set_title(tilt_string(det2))
-    det2.plot_side_view(ax=ax)
+    ax2 = fig.add_subplot(2, 3, i + 4)
+    ax2.set_title("Top view")
+    det2.plot_top_view(ax=ax2)
 
 # %%
 # Changing detector tilt
 # ======================
 
-det3 = kp.detectors.EBSDDetector()
+det3 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-detector_tilts = np.linspace(0, 90, num=9)
-nrows = 3
-ncols = int(np.ceil(detector_tilts.size / nrows))
+fig = plt.figure(figsize=(9, 6), layout="constrained")
+for i, tilt in enumerate([0, 45, 90]):
+    det3.tilt = tilt
 
-fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
-for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
-    if i > detector_tilts.size - 1:
-        break
+    ax1 = fig.add_subplot(2, 3, i + 1)
+    ax1.set_title("Side view\n" + tilt_string(det3))
+    det3.plot_side_view(ax=ax1)
 
-    det3.tilt = detector_tilts[i]
-
-    ax = fig.add_subplot(nrows, ncols, i + 1)
-    ax.set_title(tilt_string(det3))
-    det3.plot_side_view(ax=ax)
+    ax2 = fig.add_subplot(2, 3, i + 4)
+    ax2.set_title("Top view")
+    det3.plot_top_view(ax=ax2)
 
 # %%
 # Changing sample and detector tilts
@@ -116,24 +103,23 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 # Let's start with the sample tilt at :math:`\sigma = 90^{\circ}` and then decrease it
 # while increasing the detector tilt :math:`\theta` in steps of :math:`10^{\circ}`.
 
-det4 = kp.detectors.EBSDDetector()
+det4 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-sample_tilts = np.linspace(90, 0, num=9)
-detector_tilts = np.linspace(0, 90, num=9)
-nrows = 3
-ncols = int(np.ceil(detector_tilts.size / nrows))
+sample_tilts = [90, 45, 0]
+detector_tilts = sample_tilts[::-1]
 
-fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
-for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
-    if i > detector_tilts.size - 1:
-        break
+fig = plt.figure(figsize=(9, 6), layout="constrained")
+for i, (stilt, tilt) in enumerate(zip(sample_tilts, detector_tilts)):
+    det4.sample_tilt = stilt
+    det4.tilt = tilt
 
-    det4.sample_tilt = sample_tilts[i]
-    det4.tilt = detector_tilts[i]
+    ax1 = fig.add_subplot(2, 3, i + 1)
+    ax1.set_title("Side view\n" + tilt_string(det4))
+    det4.plot_side_view(ax=ax1)
 
-    ax = fig.add_subplot(nrows, ncols, i + 1)
-    ax.set_title(tilt_string(det4))
-    det4.plot_side_view(ax=ax)
+    ax2 = fig.add_subplot(2, 3, i + 4)
+    ax2.set_title("Top view")
+    det4.plot_top_view(ax=ax2)
 
 # %%
 # Changing projection center
@@ -141,10 +127,26 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 #
 # See the documentation for the :class:`~kikuchipy.detectors.EBSDDetector` for a
 # definition of the projection center (PC).
+
+# %%
+# Changing PCx
+# ------------
 #
-# Since we're looking at the geometry in side-view along the microscope X, which is
-# parallel to the detector X (and since we keep the detector azimuthal angle
-# :math:`0^{\circ}`), a change in the PCx won't show.
+# Vary PCx from :math:`0 \rightarrow 1` (top :math:`\rightarrow` bottom).
+
+det5 = kp.detectors.EBSDDetector(shape=(60, 60))
+
+fig = plt.figure(figsize=(9, 6), layout="constrained")
+for i, pcx in enumerate([0, 0.5, 1]):
+    det5.pcx = pcx
+
+    ax1 = fig.add_subplot(2, 3, i + 1)
+    ax1.set_title("Side view\n" + pc_string(det5))
+    det5.plot_side_view(ax=ax1)
+
+    ax2 = fig.add_subplot(2, 3, i + 4)
+    ax2.set_title("Top view")
+    det5.plot_top_view(ax=ax2)
 
 # %%
 # Changing PCy
@@ -152,22 +154,19 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 #
 # Vary PCy from :math:`0 \rightarrow 1` (top :math:`\rightarrow` bottom).
 
-det5 = kp.detectors.EBSDDetector()
+det6 = kp.detectors.EBSDDetector(shape=(60, 60))
 
-pcy = np.linspace(0, 1, num=9)
-nrows = 3
-ncols = int(np.ceil(pcy.size / nrows))
+fig = plt.figure(figsize=(9, 6), layout="constrained")
+for i, pcy in enumerate([0, 0.5, 1]):
+    det6.pcy = pcy
 
-fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
-for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
-    if i > pcy.size - 1:
-        break
+    ax1 = fig.add_subplot(2, 3, i + 1)
+    ax1.set_title("Side view\n" + pc_string(det6))
+    det6.plot_side_view(ax=ax1)
 
-    det5.pcy = pcy[i]
-
-    ax = fig.add_subplot(nrows, ncols, i + 1)
-    ax.set_title(pc_string(det5))
-    det5.plot_side_view(ax=ax)
+    ax2 = fig.add_subplot(2, 3, i + 4)
+    ax2.set_title("Top view")
+    det6.plot_top_view(ax=ax2)
 
 # %%
 # Changing PCz
@@ -175,28 +174,25 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 #
 # Vary PCz from :math:`0.2 \rightarrow 1` (increasing distance from the detector)
 
-det6 = kp.detectors.EBSDDetector(px_size=560)
+det7 = kp.detectors.EBSDDetector(shape=(60, 60), px_size=560)
 
-pcz = np.linspace(0.2, 1, num=9)
-nrows = 3
-ncols = int(np.ceil(pcz.size / nrows))
+fig = plt.figure(figsize=(9, 6), layout="constrained")
+for i, pcz in enumerate([0.2, 0.6, 1]):
+    det7.pcz = pcz
 
-fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="tight")
-for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
-    if i > pcz.size - 1:
-        break
+    ax1 = fig.add_subplot(2, 3, i + 1)
+    ax1.set_title("Side view\n" + pc_string(det7))
+    det7.plot_side_view(ax=ax1)
 
-    det6.pcz = pcz[i]
-
-    ax = fig.add_subplot(nrows, ncols, i + 1)
-    ax.set_title(pc_string(det6))
-    det6.plot_side_view(ax=ax)
+    ax2 = fig.add_subplot(2, 3, i + 4)
+    ax2.set_title("Top view")
+    det7.plot_top_view(ax=ax2)
 
 # %%
 # Interactive changes
 # ===================
 #
-# We can also change the sample and detector tilts and the PC values interactively.
+# We can also show both views at the same time and change all parameters interactively.
 #
 # .. note::
 #
@@ -206,6 +202,7 @@ for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
 # The default behavior is not to affect the detector.
 # Here, we want the changes to affect the detector inplace.
 
-det6.plot_side_view(interactive=True)
+det8 = kp.detectors.EBSDDetector(shape=(60, 60))
+_, fig = det8.plot_interactive(figsize=(9, 3), legend=True, return_figure=True)
 
 plt.show()

--- a/examples/reference_frames/visualize_detector_sample_reference_frame.py
+++ b/examples/reference_frames/visualize_detector_sample_reference_frame.py
@@ -1,0 +1,195 @@
+#
+# Copyright 2019-2026 the kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+==================================
+Detector-sample geometry side-view
+==================================
+
+This example shows how to view the detector-sample geometry using the
+:class:`~kikuchipy.detectors.EBSDDetector`.
+This can be useful when understanding the geometry and the definition of the detector
+parameters.
+
+.. note::
+
+    This example only shows the side-view.
+    It ignores the detector :attr:`~kikuchipy.detectors.EBSDDetector.azimuthal` and
+    :attr:`~kikuchipy.detectors.EBSDDetector.twist`.
+"""
+
+# %%
+# Imports and some reusable functions.
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import kikuchipy as kp
+
+
+def tilt_string(detector: kp.detectors.EBSDDetector) -> str:
+    return (
+        rf"sample tilt $\sigma = {detector.sample_tilt:.1f}$"
+        "\N{DEGREE SIGN}\n"
+        rf"detector tilt $\theta = {detector.tilt:.1f}$"
+        "\N{DEGREE SIGN}"
+    )
+
+
+def pc_string(detector: kp.detectors.EBSDDetector) -> str:
+    pcx, pcy, pcz = detector.pc_average.round(2)
+    return f"(PCx, PCy, PCz) = ({pcx}, {pcy}, {pcz})"
+
+
+# %%
+# Get the default detector.
+det1 = kp.detectors.EBSDDetector()
+print(det1)
+
+# %%
+# And view the detector-sample geometry.
+fig = det1.plot_side_view(annotate=True, return_figure=True)
+_ = fig.suptitle(f"Default detector-sample geometry\n{tilt_string(det1)}")
+
+# %%
+# Changing sample tilt
+# ====================
+
+det2 = kp.detectors.EBSDDetector()
+
+sample_tilts = np.linspace(0, 90, num=9)
+nrows = 3
+ncols = int(np.ceil(sample_tilts.size / nrows))
+
+fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
+for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
+    if i > sample_tilts.size - 1:
+        break
+
+    det2.sample_tilt = sample_tilts[i]
+
+    ax = fig.add_subplot(nrows, ncols, i + 1)
+    ax.set_title(tilt_string(det2))
+    det2.plot_side_view(ax=ax)
+
+# %%
+# Changing detector tilt
+# ======================
+
+det3 = kp.detectors.EBSDDetector()
+
+detector_tilts = np.linspace(0, 90, num=9)
+nrows = 3
+ncols = int(np.ceil(detector_tilts.size / nrows))
+
+fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
+for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
+    if i > detector_tilts.size - 1:
+        break
+
+    det3.tilt = detector_tilts[i]
+
+    ax = fig.add_subplot(nrows, ncols, i + 1)
+    ax.set_title(tilt_string(det3))
+    det3.plot_side_view(ax=ax)
+
+# %%
+# Changing sample and detector tilts
+# ==================================
+#
+# Let's start with the sample tilt at :math:`\sigma = 90^{\circ}` and then decrease it
+# while increasing the detector tilt :math:`\theta` in steps of :math:`10^{\circ}`.
+
+det4 = kp.detectors.EBSDDetector()
+
+sample_tilts = np.linspace(90, 0, num=9)
+detector_tilts = np.linspace(0, 90, num=9)
+nrows = 3
+ncols = int(np.ceil(detector_tilts.size / nrows))
+
+fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
+for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
+    if i > detector_tilts.size - 1:
+        break
+
+    det4.sample_tilt = sample_tilts[i]
+    det4.tilt = detector_tilts[i]
+
+    ax = fig.add_subplot(nrows, ncols, i + 1)
+    ax.set_title(tilt_string(det4))
+    det4.plot_side_view(ax=ax)
+
+# %%
+# Changing projection center
+# ==========================
+#
+# See the documentation for the :class:`~kikuchipy.detectors.EBSDDetector` for a
+# definition of the projection center (PC).
+#
+# Since we're looking at the geometry in side-view along the microscope X, which is
+# parallel to the detector X (and since we keep the detector azimuthal angle
+# :math:`0^{\circ}`), a change in the PCx won't show.
+
+# %%
+# Changing PCy
+# ------------
+#
+# Vary PCy from :math:`0 \rightarrow 1` (top :math:`\rightarrow` bottom).
+
+det5 = kp.detectors.EBSDDetector()
+
+pcy = np.linspace(0, 1, num=9)
+nrows = 3
+ncols = int(np.ceil(pcy.size / nrows))
+
+fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="constrained")
+for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
+    if i > pcy.size - 1:
+        break
+
+    det5.pcy = pcy[i]
+
+    ax = fig.add_subplot(nrows, ncols, i + 1)
+    ax.set_title(pc_string(det5))
+    det5.plot_side_view(ax=ax)
+
+# %%
+# Changing PCz
+# ------------
+#
+# Vary PCz from :math:`0.2 \rightarrow 1` (increasing distance from the detector)
+
+det6 = kp.detectors.EBSDDetector(px_size=560)
+
+pcz = np.linspace(0.2, 1, num=9)
+nrows = 3
+ncols = int(np.ceil(pcz.size / nrows))
+
+fig = plt.figure(figsize=(3 * ncols, 3 * nrows), layout="tight")
+for i, (j, k) in enumerate(np.ndindex(nrows, ncols)):
+    if i > pcz.size - 1:
+        break
+
+    det6.pcz = pcz[i]
+
+    ax = fig.add_subplot(nrows, ncols, i + 1)
+    ax.set_title(pc_string(det6))
+    det6.plot_side_view(ax=ax)
+
+plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ all = [
     "ipywidgets",
     "IPython",
     "nlopt",
-    "pyebsdindex                  >= 0.3.9.2",
+    "psygnal",
+    "pyebsdindex >= 0.3.9.2",
     "pyvista",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
+    "ipywidgets",
+    "IPython",
     "nlopt",
     "pyebsdindex                  >= 0.3.9.2",
     "pyvista",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ all = [
     "pyvista",
 ]
 doc = [
+    "ipywidgets",
+    "IPython",
     "memory_profiler",
     "nbsphinx                     >= 0.7",
     # Restriction due to https://github.com/pyxem/kikuchipy/issues/739

--- a/src/kikuchipy/_constants.py
+++ b/src/kikuchipy/_constants.py
@@ -23,14 +23,17 @@ from importlib.metadata import version
 
 from packaging.version import Version
 
+# TODO: Create this list dynamically using importlib.metadata.require
 deps_for_version_check = [
-    # Core
+    # Required
     "hyperspy",
     "matplotlib",
     "numpy",
     "rosettasciio",
     "scikit-image",
     # Optional
+    "IPython",
+    "ipywidgets",
     "nlopt",
     "pyvista",
     "pyebsdindex",

--- a/src/kikuchipy/_constants.py
+++ b/src/kikuchipy/_constants.py
@@ -35,6 +35,7 @@ deps_for_version_check = [
     "IPython",
     "ipywidgets",
     "nlopt",
+    "psygnal",
     "pyvista",
     "pyebsdindex",
 ]

--- a/src/kikuchipy/_constants.py
+++ b/src/kikuchipy/_constants.py
@@ -48,6 +48,14 @@ for dep in deps_for_version_check:
     dependency_version[dep] = dep_version
 
 
+def verify_dependency_or_raise(package: str, reason: str) -> None:
+    """Raise an informative ImportError if a *package* required for some
+    *reason* is not installed.
+    """
+    if dependency_version[package] is None:
+        raise ImportError(f"{reason} requires that {package!r} is installed")
+
+
 # PyOpenCL context available for use with PyEBSDIndex? Required for
 # Hough indexing of Dask arrays.
 # PyOpenCL is an optional dependency of PyEBSDIndex, so it should not be

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -1825,7 +1825,7 @@ class EBSDDetector:
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: Literal[False] = False,
         return_figure: Literal[False] = False,
@@ -1836,7 +1836,7 @@ class EBSDDetector:
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: Literal[True] = True,
         return_figure: Literal[False] = False,
@@ -1847,7 +1847,7 @@ class EBSDDetector:
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: Literal[False] = False,
         return_figure: Literal[True] = True,
@@ -1858,7 +1858,7 @@ class EBSDDetector:
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: Literal[True] = True,
         return_figure: Literal[True] = True,
@@ -1868,7 +1868,7 @@ class EBSDDetector:
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: bool = False,
         return_figure: bool = False,
@@ -1884,8 +1884,8 @@ class EBSDDetector:
         ax
             The Matplotlib axis to plot in. If not given, a new figure
             and axis are created.
-        annotate
-            Whether to annotate the various components of the geometry.
+        legend
+            Whether to show a legend in the upper right corner.
             Default is False.
         dimensionless
             Whether to ignore the
@@ -1901,9 +1901,9 @@ class EBSDDetector:
 
             The following attributes can be varied:
 
-            - :attr:`pc`
             - :attr:`sample_tilt`
             - :attr:`tilt`
+            - :attr:`pcy` and :attr:`pcz`
 
             The remaining attributes are ignored.
         return_figure
@@ -1934,7 +1934,7 @@ class EBSDDetector:
             controls, fig = plot_detector_sample_geometry_side_view_interactive(
                 detector=self,
                 ax=ax,
-                annotate=annotate,
+                legend=legend,
                 dimensionless=dimensionless,
                 **kwargs,
             )
@@ -1946,7 +1946,7 @@ class EBSDDetector:
             fig = plot_detector_sample_geometry_side_view(
                 detector=self,
                 ax=ax,
-                annotate=annotate,
+                legend=legend,
                 dimensionless=dimensionless,
                 **kwargs,
             )
@@ -1957,7 +1957,7 @@ class EBSDDetector:
     def plot_top_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: bool = False,
         return_figure: Literal[False] = False,
@@ -1968,7 +1968,7 @@ class EBSDDetector:
     def plot_top_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: bool = False,
         return_figure: Literal[True] = True,
@@ -1979,7 +1979,7 @@ class EBSDDetector:
     def plot_top_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: Literal[True] = True,
         return_figure: bool = False,
@@ -1990,7 +1990,7 @@ class EBSDDetector:
     def plot_top_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: Literal[True] = True,
         return_figure: Literal[True] = True,
@@ -2000,7 +2000,7 @@ class EBSDDetector:
     def plot_top_view(
         self,
         ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         interactive: bool = False,
         return_figure: bool = False,
@@ -2017,8 +2017,8 @@ class EBSDDetector:
         ax
             The Matplotlib axis to plot in. If not given, a new figure
             and axis are created.
-        annotate
-            Whether to annotate the various components of the geometry.
+        legend
+            Whether to show a legend in the upper right corner.
             Default is False.
         dimensionless
             Whether to ignore the
@@ -2034,8 +2034,8 @@ class EBSDDetector:
 
             The following attributes can be varied:
 
-            - :attr:`pcx` and :attr:`pcz`
             - :attr:`azimuthal`
+            - :attr:`pcx` and :attr:`pcz`
 
             The remaining attributes are ignored.
         return_figure
@@ -2064,7 +2064,7 @@ class EBSDDetector:
             controls, fig = plot_detector_sample_geometry_top_view_interactive(
                 detector=self,
                 ax=ax,
-                annotate=annotate,
+                legend=legend,
                 dimensionless=dimensionless,
                 **kwargs,
             )
@@ -2076,7 +2076,7 @@ class EBSDDetector:
             fig = plot_detector_sample_geometry_top_view(
                 detector=self,
                 ax=ax,
-                annotate=annotate,
+                legend=legend,
                 dimensionless=dimensionless,
                 **kwargs,
             )
@@ -2087,7 +2087,7 @@ class EBSDDetector:
     def plot_interactive(
         self,
         inplace: bool = True,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         coordinates: DETECTOR_PLOT_FORMATS = "detector",
         zoom: float = 1.0,
@@ -2099,7 +2099,7 @@ class EBSDDetector:
     def plot_interactive(
         self,
         inplace: bool = True,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         coordinates: DETECTOR_PLOT_FORMATS = "detector",
         zoom: float = 1.0,
@@ -2110,7 +2110,7 @@ class EBSDDetector:
     def plot_interactive(
         self,
         inplace: bool = True,
-        annotate: bool = False,
+        legend: bool = False,
         dimensionless: bool = True,
         coordinates: DETECTOR_PLOT_FORMATS = "detector",
         zoom: float = 1.0,
@@ -2125,9 +2125,9 @@ class EBSDDetector:
         inplace
             Whether the interactive changes affect the detector inplace.
             Default is True.
-        annotate
-            Whether to annotate the side-view components. Default is
-            False.
+        legend
+            Whether to show a legend in the upper right corner of the
+            side and top view plots. Default is False.
         dimensionless
             Whether to ignore the
             :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
@@ -2180,7 +2180,7 @@ class EBSDDetector:
         fig, widgets = plot_detector_sample_geometry_interactive(
             detector=self,
             inplace=inplace,
-            annotate=annotate,
+            legend=legend,
             dimensionless=dimensionless,
             coords_fmt=coordinates,
             zoom=zoom,

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -114,21 +114,25 @@ class EBSDDetector:
         binned into one. Default is 1, meaning no binning.
     tilt
         Detector tilt :math:`\theta` about the detector horizontal
-        :math:`X_d`, in degrees. Default is 0.0.
+        :math:`X_d`, in degrees. Default is 0. A positive angle means
+        features on the detector appear to move upward (assuming all
+        other defaults).
     azimuthal
         Detector tilt :math:`\omega` about the detector vertical
-        :math:`Y_d`, pointing downwards, in degrees. Default is 0.0. A
-        positive angle means features on the detector moves towards the
-        left looking from the detector towards the sample.
+        :math:`Y_d`, pointing downwards, in degrees. Default is 0. A
+        positive angle means features on the detector appear to move
+        toward the right (assuming all other defaults).
     twist
         Detector tilt :math:`\gamma` about the detector normal
         :math:`Z_d`, pointing towards the sample, in degrees. Default is
-        0.0.
+        0.0. A positive angle means features on the detector appear to
+        move counter-clockwise about the detector center (assuming all
+        other defaults).
     sample_tilt
         Sample tilt :math:`\sigma` about the sample horizontal,
-        :math:`Y_d`, in degrees. Default is 70.0. Note that the sample
-        horizontal :math:`Y_d` is parallel to the detector horizontal,
-        :math:`X_d`.
+        :math:`Y_d`, in degrees. Default is 70. Note that the sample
+        horizontal :math:`Y_s` is parallel to the detector horizontal,
+        :math:`X_d` (assuming all other defaults).
     pc
         X, Y, and Z coordinates of the projection centers (PCs) in the
         given *convention*. Default is [0.5, 0.5, 0.5]. The PC describes
@@ -210,6 +214,7 @@ class EBSDDetector:
 
         _sample_tilt_changed = Signal(float)
         _tilt_changed = Signal(float)
+        _azimuthal_changed = Signal(float)
         _pc_changed = Signal(np.ndarray)
 
     def __init__(
@@ -269,6 +274,9 @@ class EBSDDetector:
         if not isinstance(value, Number):
             raise ValueError(f"Invalid azimuthal {value}. Must be a number.")
         self._azimuthal = float(value)
+
+        if self._has_signals:
+            self._azimuthal_changed.emit(self._azimuthal)
 
     @property
     def binning(self) -> int:
@@ -1835,7 +1843,11 @@ class EBSDDetector:
         return_figure: bool = False,
         **kwargs,
     ) -> "mfigure.Figure | mfigure.SubFigure | None":
-        """Plot the EBSD detector-sample geometry in a 2D side-view.
+        r"""Plot the EBSD detector-sample geometry in a 2D side-view.
+
+        The view is looking down the microscope Z axis and shows the
+        X-Y plane. This is the view in which the detector azimuthal
+        angle :math:`\omega` is visible. The effect of
 
         Parameters
         ----------
@@ -1865,6 +1877,78 @@ class EBSDDetector:
         )
 
         fig = plot_ebsd_detector_geometry_side_view(
+            detector=self,
+            ax=ax,
+            annotate=annotate,
+            dimensionless=dimensionless,
+            **kwargs,
+        )
+
+        if return_figure:
+            return fig
+
+    @overload
+    def plot_top_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: Literal[False] = False,
+        **kwargs,
+    ) -> None: ...
+
+    @overload
+    def plot_top_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: Literal[True] = True,
+        **kwargs,
+    ) -> "mfigure.Figure | mfigure.SubFigure": ...
+
+    def plot_top_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: bool = False,
+        **kwargs,
+    ) -> "mfigure.Figure | mfigure.SubFigure | None":
+        r"""Plot the EBSD detector-sample geometry in a 2D top-view.
+
+        The view is looking down the microscope Z axis and shows the
+        X-Y plane. This is the view in which the detector azimuthal
+        angle :math:`\omega` is visible. The effect of
+
+        Parameters
+        ----------
+        ax
+            The Matplotlib axis to plot in. If not given, a new figure
+            and axis are created.
+        annotate
+            Whether to annotate the various components of the geometry.
+            Default is False.
+        dimensionless
+            Whether to ignore the
+            :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
+            drawing the plot axes. Default is True.
+        return_figure
+            Whether to return the figure. Default is False.
+        **kwargs
+            Keyword arguments passed to
+            :func:`~matplotlib.pyplot.figure` if *ax* is not given.
+
+        Returns
+        -------
+        fig
+            Figure showing the detector-sample geometry from the top.
+        """
+        from kikuchipy.draw._plot_ebsd_detector import (
+            plot_ebsd_detector_geometry_top_view,
+        )
+
+        fig = plot_ebsd_detector_geometry_top_view(
             detector=self,
             ax=ax,
             annotate=annotate,
@@ -1997,8 +2081,8 @@ class EBSDDetector:
         return_figure: bool = False,
         **kwargs,
     ) -> "ipywidgets.VBox | tuple[ipywidgets.VBox, mfigure.Figure]":
-        """Plot the side view and detector plane side by side with
-        interactive slider controls.
+        """Plot the side view, top view, and detector plane side by
+        side with interactive slider controls.
 
         Parameters
         ----------
@@ -2035,6 +2119,7 @@ class EBSDDetector:
         --------
         :meth:`~kikuchipy.detectors.EBSDDetector.plot`,
         :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_top_view`,
         :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view_interactive`
 
         Notes
@@ -2045,6 +2130,7 @@ class EBSDDetector:
 
         - :attr:`sample_tilt`
         - Detector :attr:`tilt`
+        - Detector :attr:`azimuthal`
         - Average :attr:`pc`, (PCx, PCy, PCz), individually
 
         If :mod:`psygnal` is installed and *inplace* is True, the plot
@@ -2069,7 +2155,6 @@ class EBSDDetector:
         if return_figure:
             return widgets, fig
         else:
-            fig.show()
             return widgets
 
     @overload

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -1782,6 +1782,26 @@ class EBSDDetector:
         if return_figure:
             return fig
 
+    @overload
+    def plot_side_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: Literal[False] = False,
+        **kwargs,
+    ) -> None: ...
+
+    @overload
+    def plot_side_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: Literal[True] = True,
+        **kwargs,
+    ) -> "mfigure.Figure | mfigure.SubFigure": ...
+
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
@@ -1804,6 +1824,8 @@ class EBSDDetector:
             Whether to ignore the
             :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
             drawing the plot axes. Default is True.
+        return_figure
+            Whether to return the figure. Default is False.
         **kwargs
             Keyword arguments passed to
             :func:`~matplotlib.pyplot.figure` if *ax* is not given.
@@ -1818,11 +1840,37 @@ class EBSDDetector:
         )
 
         fig = plot_ebsd_detector_geometry_side_view(
-            detector=self, ax=ax, annotate=annotate, dimensionless=dimensionless
+            detector=self,
+            ax=ax,
+            annotate=annotate,
+            dimensionless=dimensionless,
+            **kwargs,
         )
 
         if return_figure:
             return fig
+
+    @overload
+    def plot_side_view_interactive(
+        self,
+        inplace: bool = False,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: Literal[False] = False,
+        **kwargs,
+    ) -> "widgets.VBox": ...
+
+    @overload
+    def plot_side_view_interactive(
+        self,
+        inplace: bool = False,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: Literal[True] = True,
+        **kwargs,
+    ) -> "tuple[widgets.VBox, mfigure.Figure | mfigure.SubFigure]": ...
 
     def plot_side_view_interactive(
         self,
@@ -1830,8 +1878,9 @@ class EBSDDetector:
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        return_figure: bool = False,
         **kwargs,
-    ) -> "widgets.VBox":
+    ) -> "widgets.VBox | tuple[widgets.VBox, mfigure.Figure | mfigure.SubFigure]":
         """Plot the EBSD detector-sample geometry in a 2D side-view
         with controls for changing the sample and detector tilts and the
         projection center coordinates.
@@ -1851,6 +1900,8 @@ class EBSDDetector:
             Whether to ignore the
             :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
             drawing the plot axes. Default is True.
+        return_figure
+            Whether to return the figure. Default is False.
         **kwargs
             Keyword arguments passed to
             :func:`~matplotlib.pyplot.figure` if *ax* is not given.
@@ -1873,7 +1924,7 @@ class EBSDDetector:
             plot_ebsd_detector_geometry_side_view_interactive,
         )
 
-        widgets = plot_ebsd_detector_geometry_side_view_interactive(
+        fig, widgets = plot_ebsd_detector_geometry_side_view_interactive(
             detector=self,
             inplace=inplace,
             ax=ax,
@@ -1882,7 +1933,10 @@ class EBSDDetector:
             **kwargs,
         )
 
-        return widgets
+        if return_figure:
+            return widgets, fig
+        else:
+            return widgets
 
     @overload
     def plot_pc(

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -17,6 +17,19 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 #
 
+"""Implementation of the EBSD detector class.
+
+The class is implemented with the following goals in mind:
+
+- Enable it's use as many places in the code as possible.
+  This means that in this file, to avoid circular imports, we must
+  import from other modules inside the using detector methods, rather
+  than at the top of the file.
+- To ease understanding and extending the class, we should put
+  implementations of fitting, plotting, IO, and such in separate
+  modules, rather than here.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -38,12 +51,6 @@ from kikuchipy._utils._detector_coordinates import (
     get_coordinate_conversions,
 )
 from kikuchipy._utils.deprecated import VisibleDeprecationWarning
-from kikuchipy.detectors._fit_projection_center import (
-    estimate_xtilt_linear,
-    estimate_xtilt_linear_robust,
-    fit_hyperplane,
-    fit_plane_to_pc,
-)
 from kikuchipy.indexing._hough_indexing import _get_indexer_from_detector
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -211,13 +218,10 @@ class EBSDDetector:
         convention: PC_CONVENTIONS | None = "bruker",
     ) -> None:
         self.shape = shape
-
         self.px_size = px_size
-
         # .binning returns an integer, while ._binning should always be
         # a float. Use the latter for any computation.
         self.binning = binning
-
         self.tilt = tilt
         self.azimuthal = azimuthal
         self.twist = twist
@@ -235,7 +239,6 @@ class EBSDDetector:
                 category=VisibleDeprecationWarning,
             )
             convention = "bruker"
-
         self._set_pc_in_bruker_convention(convention)
 
     # -------------------------- Properties -------------------------- #
@@ -1093,22 +1096,22 @@ class EBSDDetector:
         estimate_xtilt_ztilt,
         fit_pc
         """
+        from kikuchipy.detectors._fit_projection_center import (
+            estimate_xtilt_linear,
+            estimate_xtilt_linear_robust,
+        )
         from kikuchipy.draw._plot_ebsd_detector import plot_xtilt_estimate
 
         if self.navigation_size == 1:
             raise ValueError("Estimation requires more than one projection center")
-        pcy = self.pcy.reshape((-1, 1))
-        pcz = self.pcz.reshape((-1, 1))
 
         if return_outliers:
             detect_outliers = True
 
         if detect_outliers:
-            x_tilt, regressor, is_outlier = estimate_xtilt_linear_robust(
-                pcy=pcy, pcz=pcz
-            )
+            x_tilt, regressor, is_outlier = estimate_xtilt_linear_robust(detector=self)
         else:
-            x_tilt, regressor = estimate_xtilt_linear(pcy=pcy, pcz=pcz)
+            x_tilt, regressor = estimate_xtilt_linear(detector=self)
             is_outlier = None
 
         if degrees:
@@ -1121,6 +1124,8 @@ class EBSDDetector:
             out += (is_outlier_2d,)
 
         if plot:
+            pcy = self.pcy.reshape((-1, 1))
+            pcz = self.pcz.reshape((-1, 1))
             pcz_fit = np.linspace(np.min(pcz), np.max(pcz), 2)
             pcy_fit = regressor.predict(pcz_fit[:, np.newaxis])
             if figure_kwargs is None:
@@ -1192,6 +1197,8 @@ class EBSDDetector:
         --------
         estimate_xtilt, fit_pc
         """
+        from kikuchipy.detectors._fit_projection_center import fit_hyperplane
+
         if self.navigation_size == 1:
             raise ValueError("Estimation requires more than one projection center")
 
@@ -1416,6 +1423,7 @@ class EBSDDetector:
         (https://stackoverflow.com/a/20555267/3228100) for the affine
         transformation.
         """
+        from kikuchipy.detectors._fit_projection_center import fit_plane_to_pc
         from kikuchipy.draw._plot_ebsd_detector import plot_projection_center_fit
 
         n_pc = self.navigation_size
@@ -1449,8 +1457,7 @@ class EBSDDetector:
             )
 
         pc_fit, pc_fit_map, pc_flat, x_tilt, intercept, slope = fit_plane_to_pc(
-            n_pc=n_pc,
-            pc_flat=self.pc_flattened,
+            detector=self,
             pc_indices=pc_indices,
             map_indices=map_indices,
             is_outlier=is_outlier,
@@ -1946,6 +1953,20 @@ class EBSDDetector:
 
     # ------------------------ Private methods ----------------------- #
 
+    @staticmethod
+    def _get_pc_convention_or_raise(conv: PC_CONVENTIONS) -> PC_CONVENTIONS_SINGLE:
+        conv_lower = conv.lower()
+        for k, v in PC_CONVENTIONS_ALIASES.items():
+            if conv_lower in v:
+                return k
+        else:
+            options = get_args(PC_CONVENTIONS)
+            options_str = ", ".join(options)
+            raise ValueError(
+                f"Invalid projection/pattern center convention {conv!r}. Options are "
+                f"{options_str}."
+            )
+
     def _get_pc_in_bruker_convention(
         self, convention: PC_CONVENTIONS = "bruker"
     ) -> np.ndarray:
@@ -1975,11 +1996,6 @@ class EBSDDetector:
             return self._pc_emsoft2bruker(version)
         else:
             return self.pc
-
-    def _set_pc_in_bruker_convention(
-        self, convention: PC_CONVENTIONS = "bruker"
-    ) -> None:
-        self.pc = self._get_pc_in_bruker_convention(convention)
 
     def _get_pc_in_convention(
         self, convention: PC_CONVENTIONS = "bruker"
@@ -2011,6 +2027,20 @@ class EBSDDetector:
             return self._pc_bruker2emsoft(version)
         else:
             return self.pc
+
+    @staticmethod
+    def _parse_valid_shape_or_raise(value: tuple[int, int]) -> tuple[int, int]:
+        if (
+            not isinstance(value, Iterable)
+            or len(value) != 2
+            or not all(isinstance(ni, Number) for ni in value)
+        ):
+            raise ValueError(
+                f"Invalid shape {value}. Must be an iterable of two integers."
+            )
+        ny, nx = value
+        shape = (int(ny), int(nx))
+        return shape
 
     def _pc_emsoft2bruker(self, version: int = 5) -> np.ndarray:
         new_pc = np.zeros_like(self.pc, dtype=float)
@@ -2055,30 +2085,7 @@ class EBSDDetector:
         new_pc[..., 2] /= self.aspect_ratio
         return new_pc
 
-    @staticmethod
-    def _parse_valid_shape_or_raise(value: tuple[int, int]) -> tuple[int, int]:
-        if (
-            not isinstance(value, Iterable)
-            or len(value) != 2
-            or not all(isinstance(ni, Number) for ni in value)
-        ):
-            raise ValueError(
-                f"Invalid shape {value}. Must be an iterable of two integers."
-            )
-        ny, nx = value
-        shape = (int(ny), int(nx))
-        return shape
-
-    @staticmethod
-    def _get_pc_convention_or_raise(conv: PC_CONVENTIONS) -> PC_CONVENTIONS_SINGLE:
-        conv_lower = conv.lower()
-        for k, v in PC_CONVENTIONS_ALIASES.items():
-            if conv_lower in v:
-                return k
-        else:
-            options = get_args(PC_CONVENTIONS)
-            options_str = ", ".join(options)
-            raise ValueError(
-                f"Invalid projection/pattern center convention {conv!r}. Options are "
-                f"{options_str}."
-            )
+    def _set_pc_in_bruker_convention(
+        self, convention: PC_CONVENTIONS = "bruker"
+    ) -> None:
+        self.pc = self._get_pc_in_bruker_convention(convention)

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -2089,7 +2089,7 @@ class EBSDDetector:
         inplace: bool = True,
         legend: bool = False,
         dimensionless: bool = True,
-        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        coordinates: DETECTOR_PLOT_FORMATS = "gnomonic",
         zoom: float = 1.0,
         return_figure: Literal[False] = False,
         **kwargs,
@@ -2101,7 +2101,7 @@ class EBSDDetector:
         inplace: bool = True,
         legend: bool = False,
         dimensionless: bool = True,
-        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        coordinates: DETECTOR_PLOT_FORMATS = "gnomonic",
         zoom: float = 1.0,
         return_figure: Literal[True] = True,
         **kwargs,
@@ -2112,7 +2112,7 @@ class EBSDDetector:
         inplace: bool = True,
         legend: bool = False,
         dimensionless: bool = True,
-        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        coordinates: DETECTOR_PLOT_FORMATS = "gnomonic",
         zoom: float = 1.0,
         return_figure: bool = False,
         **kwargs,
@@ -2133,8 +2133,8 @@ class EBSDDetector:
             :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
             drawing the side-view plot axes. Default is True.
         coordinates
-            Detector plane coordinate format: "detector" (default) or
-            "gnomonic".
+            Detector plane coordinate format: "gnomonic" (default) or
+            "detector".
         zoom
             Zoom factor for the detector plane. Default is 1.0.
         return_figure

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -53,21 +53,18 @@ from kikuchipy._utils._detector_coordinates import (
 from kikuchipy._utils.deprecated import VisibleDeprecationWarning
 from kikuchipy.indexing._hough_indexing import _get_indexer_from_detector
 
+# Repeated in plotting module
+DETECTOR_PLOT_FORMATS = Literal["detector", "gnomonic"]
+PROJECTION_CENTER_PLOT_MODES = Literal["map", "scatter", "3d"]
+
 if TYPE_CHECKING:  # pragma: no cover
-    from diffsims.crystallography import ReciprocalLatticeVector
     import matplotlib.axes as maxes
     import matplotlib.figure as mfigure
 
-    from kikuchipy.draw._plot_ebsd_detector import (
-        DETECTOR_PLOT_FORMATS,
-        PROJECTION_CENTER_PLOT_MODES,
-    )
-
     if dependency_version["pyebsdindex"] is not None:
         from pyebsdindex.ebsd_index import EBSDIndexer
-
     if dependency_version["ipywidgets"] is not None:
-        import ipywidgets as widgets
+        import ipywidgets
 
 
 PC_CONVENTIONS = Literal[
@@ -208,6 +205,13 @@ class EBSDDetector:
     supplementary material to :cite:`britton2016tutorial`.
     """
 
+    if dependency_version["psygnal"] is not None:
+        from psygnal import Signal
+
+        _sample_tilt_changed = Signal(float)
+        _tilt_changed = Signal(float)
+        _pc_changed = Signal(np.ndarray)
+
     def __init__(
         self,
         shape: tuple[int, int] = (1, 1),
@@ -220,6 +224,8 @@ class EBSDDetector:
         pc: np.ndarray | list | tuple = (0.5, 0.5, 0.5),
         convention: PC_CONVENTIONS | None = "bruker",
     ) -> None:
+        self._has_signals = hasattr(self, "_sample_tilt_changed")
+
         self.shape = shape
         self.px_size = px_size
         # .binning returns an integer, while ._binning should always be
@@ -385,6 +391,9 @@ class EBSDDetector:
     def pc(self, value: np.ndarray | list | tuple) -> None:
         self._pc = np.atleast_2d(value).astype(float)
 
+        if self._has_signals:
+            self._pc_changed.emit(self._pc)
+
     @property
     def pc_average(self) -> np.ndarray:
         """Return the average projection center.
@@ -436,6 +445,9 @@ class EBSDDetector:
     def pcx(self, value: np.ndarray | list | tuple | float):
         self._pc[..., 0] = np.atleast_2d(value).astype(float)
 
+        if self._has_signals:
+            self._pc_changed.emit(self._pc)
+
     @property
     def pcy(self) -> np.ndarray:
         """Return or set the projection center (PC) y coordinates.
@@ -458,6 +470,9 @@ class EBSDDetector:
     def pcy(self, value: np.ndarray | list | tuple | float):
         self._pc[..., 1] = np.atleast_2d(value).astype(float)
 
+        if self._has_signals:
+            self._pc_changed.emit(self._pc)
+
     @property
     def pcz(self) -> np.ndarray:
         """Return or set the projection center (PC) z coordinates.
@@ -479,6 +494,9 @@ class EBSDDetector:
     @pcz.setter
     def pcz(self, value: np.ndarray | list | tuple | float):
         self._pc[..., 2] = np.atleast_2d(value).astype(float)
+
+        if self._has_signals:
+            self._pc_changed.emit(self._pc)
 
     @property
     def px_size(self) -> float:
@@ -714,6 +732,9 @@ class EBSDDetector:
             raise ValueError(f"Invalid sample tilt {value}. Must be a number.")
         self._sample_tilt = float(value)
 
+        if self._has_signals:
+            self._sample_tilt_changed.emit(self._sample_tilt)
+
     @property
     def tilt(self) -> float:
         r"""Return or set the detector tilt :math:`\theta` about the
@@ -731,6 +752,9 @@ class EBSDDetector:
         if not isinstance(value, Number):
             raise ValueError(f"Invalid detector tilt {value}. Must be a number.")
         self._tilt = float(value)
+
+        if self._has_signals:
+            self._tilt_changed.emit(self._tilt)
 
     @property
     def twist(self) -> float:
@@ -1671,7 +1695,7 @@ class EBSDDetector:
     @overload
     def plot(
         self,
-        coordinates: "DETECTOR_PLOT_FORMATS" = "detector",
+        coordinates: DETECTOR_PLOT_FORMATS = "detector",
         show_pc: bool = ...,
         pc_kwargs: dict | None = None,
         pattern: np.ndarray | None = None,
@@ -1686,7 +1710,7 @@ class EBSDDetector:
     @overload
     def plot(
         self,
-        coordinates: "DETECTOR_PLOT_FORMATS" = "detector",
+        coordinates: DETECTOR_PLOT_FORMATS = "detector",
         show_pc: bool = ...,
         pc_kwargs: dict | None = None,
         pattern: np.ndarray | None = None,
@@ -1700,7 +1724,7 @@ class EBSDDetector:
 
     def plot(
         self,
-        coordinates: "DETECTOR_PLOT_FORMATS" = "detector",
+        coordinates: DETECTOR_PLOT_FORMATS = "detector",
         show_pc: bool = True,
         pc_kwargs: dict | None = None,
         pattern: np.ndarray | None = None,
@@ -1779,6 +1803,7 @@ class EBSDDetector:
             gnomonic_circles_kwargs=gnomonic_circles_kwargs,
             gnomonic_angles=gnomonic_angles,
         )
+
         if return_figure:
             return fig
 
@@ -1859,7 +1884,7 @@ class EBSDDetector:
         dimensionless: bool = True,
         return_figure: Literal[False] = False,
         **kwargs,
-    ) -> "widgets.VBox": ...
+    ) -> "ipywidgets.VBox": ...
 
     @overload
     def plot_side_view_interactive(
@@ -1870,7 +1895,7 @@ class EBSDDetector:
         dimensionless: bool = True,
         return_figure: Literal[True] = True,
         **kwargs,
-    ) -> "tuple[widgets.VBox, mfigure.Figure | mfigure.SubFigure]": ...
+    ) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]": ...
 
     def plot_side_view_interactive(
         self,
@@ -1880,7 +1905,7 @@ class EBSDDetector:
         dimensionless: bool = True,
         return_figure: bool = False,
         **kwargs,
-    ) -> "widgets.VBox | tuple[widgets.VBox, mfigure.Figure | mfigure.SubFigure]":
+    ) -> "ipywidgets.VBox | tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]":
         """Plot the EBSD detector-sample geometry in a 2D side-view
         with controls for changing the sample and detector tilts and the
         projection center coordinates.
@@ -1939,9 +1964,118 @@ class EBSDDetector:
             return widgets
 
     @overload
+    def plot_interactive(
+        self,
+        inplace: bool = False,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        zoom: float = 1.0,
+        return_figure: Literal[False] = False,
+        **kwargs,
+    ) -> "ipywidgets.VBox": ...
+
+    @overload
+    def plot_interactive(
+        self,
+        inplace: bool = False,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        zoom: float = 1.0,
+        return_figure: Literal[True] = True,
+        **kwargs,
+    ) -> "tuple[ipywidgets.VBox, mfigure.Figure]": ...
+
+    def plot_interactive(
+        self,
+        inplace: bool = False,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        zoom: float = 1.0,
+        return_figure: bool = False,
+        **kwargs,
+    ) -> "ipywidgets.VBox | tuple[ipywidgets.VBox, mfigure.Figure]":
+        """Plot the side view and detector plane side by side with
+        interactive slider controls.
+
+        Parameters
+        ----------
+        inplace
+            Whether the interactive changes affect the detector inplace.
+            Default is False.
+        annotate
+            Whether to annotate the side-view components. Default is
+            False.
+        dimensionless
+            Whether to ignore the
+            :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
+            drawing the side-view plot axes. Default is True.
+        coordinates
+            Detector plane coordinate format: "detector" (default) or
+            "gnomonic".
+        zoom
+            Zoom factor for the detector plane. Default is 1.0.
+        return_figure
+            Whether to return the figure. Default is False. If False,
+            :meth:`matplotlib.figure.Figure.show` is called before
+            returning.
+        **kwargs
+            Keyword arguments passed to
+            :func:`~matplotlib.pyplot.figure`.
+
+        Returns
+        -------
+        widgets
+            The widget containing the sliders. Required to display the
+            interactive controls.
+
+        See Also
+        --------
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view_interactive`
+
+        Notes
+        -----
+        Requires that :mod:`ipywidgets` is installed.
+
+        Parameters to vary:
+
+        - :attr:`sample_tilt`
+        - Detector :attr:`tilt`
+        - Average :attr:`pc`, (PCx, PCy, PCz), individually
+
+        If :mod:`psygnal` is installed and *inplace* is True, the plot
+        can be updated by any change to the above parameters, not just
+        via the slider controls. However, any change not done via the
+        sliders will not affect the sliders.
+        """
+        from kikuchipy.draw._plot_ebsd_detector import (
+            plot_ebsd_detector_combined_interactive,
+        )
+
+        fig, widgets = plot_ebsd_detector_combined_interactive(
+            detector=self,
+            inplace=inplace,
+            annotate=annotate,
+            dimensionless=dimensionless,
+            coords_fmt=coordinates,
+            zoom=zoom,
+            **kwargs,
+        )
+
+        if return_figure:
+            return widgets, fig
+        else:
+            fig.show()
+            return widgets
+
+    @overload
     def plot_pc(
         self,
-        mode: "PROJECTION_CENTER_PLOT_MODES" = "map",
+        mode: PROJECTION_CENTER_PLOT_MODES = "map",
         return_figure: Literal[False] = False,
         orientation: Literal["horizontal", "vertical"] = "horizontal",
         annotate: bool = False,
@@ -1952,7 +2086,7 @@ class EBSDDetector:
     @overload
     def plot_pc(
         self,
-        mode: "PROJECTION_CENTER_PLOT_MODES" = ...,
+        mode: PROJECTION_CENTER_PLOT_MODES = ...,
         return_figure: Literal[True] = True,
         orientation: Literal["horizontal", "vertical"] = ...,
         annotate: bool = ...,
@@ -1962,7 +2096,7 @@ class EBSDDetector:
 
     def plot_pc(
         self,
-        mode: "PROJECTION_CENTER_PLOT_MODES" = "map",
+        mode: PROJECTION_CENTER_PLOT_MODES = "map",
         return_figure: bool = False,
         orientation: Literal["horizontal", "vertical"] = "horizontal",
         annotate: bool = False,
@@ -2003,6 +2137,9 @@ class EBSDDetector:
         -------
         fig
             Figure is returned if *return_figure* is True.
+
+        See Also
+        --------
         """
         from kikuchipy.draw._plot_ebsd_detector import plot_all_projection_centers
 

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -1790,6 +1790,12 @@ class EBSDDetector:
         -------
         fig
             Matplotlib figure instance, if *return_figure* is True.
+
+        See Also
+        --------
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_top_view`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_interactive`
         """
         from kikuchipy.draw._plot_ebsd_detector import plot_ebsd_detector
 
@@ -1821,6 +1827,7 @@ class EBSDDetector:
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        interactive: Literal[False] = False,
         return_figure: Literal[False] = False,
         **kwargs,
     ) -> None: ...
@@ -1831,23 +1838,46 @@ class EBSDDetector:
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        interactive: Literal[True] = True,
+        return_figure: Literal[False] = False,
+        **kwargs,
+    ) -> "ipywidgets.VBox": ...
+
+    @overload
+    def plot_side_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        interactive: Literal[False] = False,
         return_figure: Literal[True] = True,
         **kwargs,
     ) -> "mfigure.Figure | mfigure.SubFigure": ...
+
+    @overload
+    def plot_side_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        interactive: Literal[True] = True,
+        return_figure: Literal[True] = True,
+        **kwargs,
+    ) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]": ...
 
     def plot_side_view(
         self,
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        interactive: bool = False,
         return_figure: bool = False,
         **kwargs,
-    ) -> "mfigure.Figure | mfigure.SubFigure | None":
+    ) -> "None | ipywidgets.VBox | tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure] | mfigure.Figure | mfigure.SubFigure":
         r"""Plot the EBSD detector-sample geometry in a 2D side-view.
 
         The view is looking down the microscope Z axis and shows the
-        X-Y plane. This is the view in which the detector azimuthal
-        angle :math:`\omega` is visible. The effect of
+        X-Y plane.
 
         Parameters
         ----------
@@ -1861,6 +1891,21 @@ class EBSDDetector:
             Whether to ignore the
             :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
             drawing the plot axes. Default is True.
+        interactive
+            Whether to return slider controls to interactively vary the
+            relevant detector-sample geometry parameters in the
+            side-view. Default is False. If True, the detector is varied
+            inplace. Requires that :mod:`ipywidgets` is installed. If
+            :mod:`psygnal` is installed, the plot is driven by signals
+            emitted from the detector property setters.
+
+            The following attributes can be varied:
+
+            - :attr:`pc`
+            - :attr:`sample_tilt`
+            - :attr:`tilt`
+
+            The remaining attributes are ignored.
         return_figure
             Whether to return the figure. Default is False.
         **kwargs
@@ -1869,23 +1914,44 @@ class EBSDDetector:
 
         Returns
         -------
+        controls
+            The slider controls. Must be displayed using IPython.
         fig
             Figure showing the detector-sample geometry.
+
+        See Also
+        --------
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_top_view`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_interactive`
         """
         from kikuchipy.draw._plot_ebsd_detector import (
-            plot_ebsd_detector_geometry_side_view,
+            plot_detector_sample_geometry_side_view,
+            plot_detector_sample_geometry_side_view_interactive,
         )
 
-        fig = plot_ebsd_detector_geometry_side_view(
-            detector=self,
-            ax=ax,
-            annotate=annotate,
-            dimensionless=dimensionless,
-            **kwargs,
-        )
-
-        if return_figure:
-            return fig
+        if interactive:
+            controls, fig = plot_detector_sample_geometry_side_view_interactive(
+                detector=self,
+                ax=ax,
+                annotate=annotate,
+                dimensionless=dimensionless,
+                **kwargs,
+            )
+            if return_figure:
+                return controls, fig
+            else:
+                return controls
+        else:
+            fig = plot_detector_sample_geometry_side_view(
+                detector=self,
+                ax=ax,
+                annotate=annotate,
+                dimensionless=dimensionless,
+                **kwargs,
+            )
+            if return_figure:
+                return fig
 
     @overload
     def plot_top_view(
@@ -1893,6 +1959,7 @@ class EBSDDetector:
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        interactive: bool = False,
         return_figure: Literal[False] = False,
         **kwargs,
     ) -> None: ...
@@ -1903,18 +1970,42 @@ class EBSDDetector:
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        interactive: bool = False,
         return_figure: Literal[True] = True,
         **kwargs,
     ) -> "mfigure.Figure | mfigure.SubFigure": ...
+
+    @overload
+    def plot_top_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        interactive: Literal[True] = True,
+        return_figure: bool = False,
+        **kwargs,
+    ) -> "ipywidgets.VBox": ...
+
+    @overload
+    def plot_top_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        interactive: Literal[True] = True,
+        return_figure: Literal[True] = True,
+        **kwargs,
+    ) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]": ...
 
     def plot_top_view(
         self,
         ax: "maxes.Axes | None" = None,
         annotate: bool = False,
         dimensionless: bool = True,
+        interactive: bool = False,
         return_figure: bool = False,
         **kwargs,
-    ) -> "mfigure.Figure | mfigure.SubFigure | None":
+    ) -> "None | ipywidgets.VBox | tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure] | mfigure.Figure | mfigure.SubFigure":
         r"""Plot the EBSD detector-sample geometry in a 2D top-view.
 
         The view is looking down the microscope Z axis and shows the
@@ -1933,6 +2024,21 @@ class EBSDDetector:
             Whether to ignore the
             :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
             drawing the plot axes. Default is True.
+        interactive
+            Whether to return slider controls to interactively vary the
+            relevant detector-sample geometry parameters in the
+            top-view. Default is False. If True, the detector is varied
+            inplace. Requires that :mod:`ipywidgets` is installed. If
+            :mod:`psygnal` is installed, the plot is driven by signals
+            emitted from the detector property setters.
+
+            The following attributes can be varied:
+
+            - :attr:`pc`
+            - :attr:`azimuthal`
+            - :attr:`tilt`
+
+            The remaining attributes are ignored.
         return_figure
             Whether to return the figure. Default is False.
         **kwargs
@@ -1943,109 +2049,40 @@ class EBSDDetector:
         -------
         fig
             Figure showing the detector-sample geometry from the top.
-        """
-        from kikuchipy.draw._plot_ebsd_detector import (
-            plot_ebsd_detector_geometry_top_view,
-        )
-
-        fig = plot_ebsd_detector_geometry_top_view(
-            detector=self,
-            ax=ax,
-            annotate=annotate,
-            dimensionless=dimensionless,
-            **kwargs,
-        )
-
-        if return_figure:
-            return fig
-
-    @overload
-    def plot_side_view_interactive(
-        self,
-        inplace: bool = False,
-        ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
-        dimensionless: bool = True,
-        return_figure: Literal[False] = False,
-        **kwargs,
-    ) -> "ipywidgets.VBox": ...
-
-    @overload
-    def plot_side_view_interactive(
-        self,
-        inplace: bool = False,
-        ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
-        dimensionless: bool = True,
-        return_figure: Literal[True] = True,
-        **kwargs,
-    ) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]": ...
-
-    def plot_side_view_interactive(
-        self,
-        inplace: bool = False,
-        ax: "maxes.Axes | None" = None,
-        annotate: bool = False,
-        dimensionless: bool = True,
-        return_figure: bool = False,
-        **kwargs,
-    ) -> "ipywidgets.VBox | tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]":
-        """Plot the EBSD detector-sample geometry in a 2D side-view
-        with controls for changing the sample and detector tilts and the
-        projection center coordinates.
-
-        Parameters
-        ----------
-        inplace
-            Whether the interactive changes affect the detector inplace.
-            Default is False.
-        ax
-            The Matplotlib axis to plot in. If not given, a new figure
-            and axis are created.
-        annotate
-            Whether to annotate the various components of the geometry.
-            Default is False.
-        dimensionless
-            Whether to ignore the
-            :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
-            drawing the plot axes. Default is True.
-        return_figure
-            Whether to return the figure. Default is False.
-        **kwargs
-            Keyword arguments passed to
-            :func:`~matplotlib.pyplot.figure` if *ax* is not given.
-
-        Returns
-        -------
-        widgets
-            The widget containing the sliders. Required to display the
-            interactive controls.
 
         See Also
         --------
-        plot_side_view
-
-        Notes
-        -----
-        Requires that :mod:`ipywidgets` is installed.
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot`,
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_interactive`
         """
         from kikuchipy.draw._plot_ebsd_detector import (
-            plot_ebsd_detector_geometry_side_view_interactive,
+            plot_detector_sample_geometry_top_view,
+            plot_detector_sample_geometry_top_view_interactive,
         )
 
-        fig, widgets = plot_ebsd_detector_geometry_side_view_interactive(
-            detector=self,
-            inplace=inplace,
-            ax=ax,
-            annotate=annotate,
-            dimensionless=dimensionless,
-            **kwargs,
-        )
-
-        if return_figure:
-            return widgets, fig
+        if interactive:
+            controls, fig = plot_detector_sample_geometry_top_view_interactive(
+                detector=self,
+                ax=ax,
+                annotate=annotate,
+                dimensionless=dimensionless,
+                **kwargs,
+            )
+            if return_figure:
+                return controls, fig
+            else:
+                return controls
         else:
-            return widgets
+            fig = plot_detector_sample_geometry_top_view(
+                detector=self,
+                ax=ax,
+                annotate=annotate,
+                dimensionless=dimensionless,
+                **kwargs,
+            )
+            if return_figure:
+                return fig
 
     @overload
     def plot_interactive(
@@ -2119,8 +2156,7 @@ class EBSDDetector:
         --------
         :meth:`~kikuchipy.detectors.EBSDDetector.plot`,
         :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view`,
-        :meth:`~kikuchipy.detectors.EBSDDetector.plot_top_view`,
-        :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view_interactive`
+        :meth:`~kikuchipy.detectors.EBSDDetector.plot_top_view`
 
         Notes
         -----
@@ -2139,10 +2175,10 @@ class EBSDDetector:
         sliders will not affect the sliders.
         """
         from kikuchipy.draw._plot_ebsd_detector import (
-            plot_ebsd_detector_combined_interactive,
+            plot_detector_sample_geometry_interactive,
         )
 
-        fig, widgets = plot_ebsd_detector_combined_interactive(
+        fig, widgets = plot_detector_sample_geometry_interactive(
             detector=self,
             inplace=inplace,
             annotate=annotate,
@@ -2222,9 +2258,6 @@ class EBSDDetector:
         -------
         fig
             Figure is returned if *return_figure* is True.
-
-        See Also
-        --------
         """
         from kikuchipy.draw._plot_ebsd_detector import plot_all_projection_centers
 

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -44,19 +44,17 @@ from kikuchipy.detectors._fit_projection_center import (
     fit_hyperplane,
     fit_plane_to_pc,
 )
-from kikuchipy.draw._plot_ebsd_detector import (
-    DETECTOR_PLOT_FORMATS,
-    PROJECTION_CENTER_PLOT_MODES,
-    plot_all_projection_centers,
-    plot_ebsd_detector,
-    plot_projection_center_fit,
-    plot_xtilt_estimate,
-)
 from kikuchipy.indexing._hough_indexing import _get_indexer_from_detector
 
 if TYPE_CHECKING:  # pragma: no cover
     from diffsims.crystallography import ReciprocalLatticeVector
+    import matplotlib.axes as maxes
     import matplotlib.figure as mfigure
+
+    from kikuchipy.draw._plot_ebsd_detector import (
+        DETECTOR_PLOT_FORMATS,
+        PROJECTION_CENTER_PLOT_MODES,
+    )
 
     if dependency_version["pyebsdindex"] is not None:
         from pyebsdindex.ebsd_index import EBSDIndexer
@@ -1095,6 +1093,8 @@ class EBSDDetector:
         estimate_xtilt_ztilt,
         fit_pc
         """
+        from kikuchipy.draw._plot_ebsd_detector import plot_xtilt_estimate
+
         if self.navigation_size == 1:
             raise ValueError("Estimation requires more than one projection center")
         pcy = self.pcy.reshape((-1, 1))
@@ -1416,6 +1416,8 @@ class EBSDDetector:
         (https://stackoverflow.com/a/20555267/3228100) for the affine
         transformation.
         """
+        from kikuchipy.draw._plot_ebsd_detector import plot_projection_center_fit
+
         n_pc = self.navigation_size
         if n_pc == 1:
             raise ValueError("Fitting requires multiple projection centers (PCs)")
@@ -1659,7 +1661,7 @@ class EBSDDetector:
     @overload
     def plot(
         self,
-        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        coordinates: "DETECTOR_PLOT_FORMATS" = "detector",
         show_pc: bool = ...,
         pc_kwargs: dict | None = None,
         pattern: np.ndarray | None = None,
@@ -1674,7 +1676,7 @@ class EBSDDetector:
     @overload
     def plot(
         self,
-        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        coordinates: "DETECTOR_PLOT_FORMATS" = "detector",
         show_pc: bool = ...,
         pc_kwargs: dict | None = None,
         pattern: np.ndarray | None = None,
@@ -1688,7 +1690,7 @@ class EBSDDetector:
 
     def plot(
         self,
-        coordinates: DETECTOR_PLOT_FORMATS = "detector",
+        coordinates: "DETECTOR_PLOT_FORMATS" = "detector",
         show_pc: bool = True,
         pc_kwargs: dict | None = None,
         pattern: np.ndarray | None = None,
@@ -1747,6 +1749,8 @@ class EBSDDetector:
         fig
             Matplotlib figure instance, if *return_figure* is True.
         """
+        from kikuchipy.draw._plot_ebsd_detector import plot_ebsd_detector
+
         if pattern_kwargs is None:
             pattern_kwargs = {}
         if pc_kwargs is None:
@@ -1754,10 +1758,7 @@ class EBSDDetector:
         if gnomonic_circles_kwargs is None:
             gnomonic_circles_kwargs = {}
         fig = plot_ebsd_detector(
-            shape=self.shape,
-            pcxy=self.pc_average[:2],
-            bounds=self.bounds,
-            average_gnomonic_bounds=self._average_gnomonic_bounds,
+            detector=self,
             coords_fmt=coordinates,
             zoom=zoom,
             show_pc=show_pc,
@@ -1771,10 +1772,53 @@ class EBSDDetector:
         if return_figure:
             return fig
 
+    def plot_side_view(
+        self,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        return_figure: bool = False,
+    ) -> "mfigure.Figure | mfigure.SubFigure | None":
+        """Plot the EBSD detector-sample geometry in a 2D side-view.
+
+        Parameters
+        ----------
+        detector
+            EBSD detector.
+        ax
+            The Matplotlib axis to plot in. If not given, a new figure
+            and axis are created.
+        annotate
+            Whether to annotate the various components of the geometry.
+            Default is False.
+        dimensionless
+            Whether to ignore the
+            :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
+            drawing the plot axes. Default is True.
+        **kwargs
+            Keyword arguments passed to
+            :func:`~matplotlib.pyplot.figure` if *ax* is not given.
+
+        Returns
+        -------
+        fig
+            Figure showing the detector-sample geometry.
+        """
+        from kikuchipy.draw._plot_ebsd_detector import (
+            plot_ebsd_detector_geometry_side_view,
+        )
+
+        fig = plot_ebsd_detector_geometry_side_view(
+            detector=self, ax=ax, annotate=annotate, dimensionless=dimensionless
+        )
+
+        if return_figure:
+            return fig
+
     @overload
     def plot_pc(
         self,
-        mode: PROJECTION_CENTER_PLOT_MODES = "map",
+        mode: "PROJECTION_CENTER_PLOT_MODES" = "map",
         return_figure: Literal[False] = False,
         orientation: Literal["horizontal", "vertical"] = "horizontal",
         annotate: bool = False,
@@ -1785,7 +1829,7 @@ class EBSDDetector:
     @overload
     def plot_pc(
         self,
-        mode: PROJECTION_CENTER_PLOT_MODES = ...,
+        mode: "PROJECTION_CENTER_PLOT_MODES" = ...,
         return_figure: Literal[True] = True,
         orientation: Literal["horizontal", "vertical"] = ...,
         annotate: bool = ...,
@@ -1795,7 +1839,7 @@ class EBSDDetector:
 
     def plot_pc(
         self,
-        mode: PROJECTION_CENTER_PLOT_MODES = "map",
+        mode: "PROJECTION_CENTER_PLOT_MODES" = "map",
         return_figure: bool = False,
         orientation: Literal["horizontal", "vertical"] = "horizontal",
         annotate: bool = False,
@@ -1837,6 +1881,8 @@ class EBSDDetector:
         fig
             Figure is returned if *return_figure* is True.
         """
+        from kikuchipy.draw._plot_ebsd_detector import plot_all_projection_centers
+
         # Ensure there are PCs to plot
         if self.navigation_size == 1:
             raise ValueError(

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -2034,9 +2034,8 @@ class EBSDDetector:
 
             The following attributes can be varied:
 
-            - :attr:`pc`
+            - :attr:`pcx` and :attr:`pcz`
             - :attr:`azimuthal`
-            - :attr:`tilt`
 
             The remaining attributes are ignored.
         return_figure
@@ -2087,7 +2086,7 @@ class EBSDDetector:
     @overload
     def plot_interactive(
         self,
-        inplace: bool = False,
+        inplace: bool = True,
         annotate: bool = False,
         dimensionless: bool = True,
         coordinates: DETECTOR_PLOT_FORMATS = "detector",
@@ -2099,7 +2098,7 @@ class EBSDDetector:
     @overload
     def plot_interactive(
         self,
-        inplace: bool = False,
+        inplace: bool = True,
         annotate: bool = False,
         dimensionless: bool = True,
         coordinates: DETECTOR_PLOT_FORMATS = "detector",
@@ -2110,7 +2109,7 @@ class EBSDDetector:
 
     def plot_interactive(
         self,
-        inplace: bool = False,
+        inplace: bool = True,
         annotate: bool = False,
         dimensionless: bool = True,
         coordinates: DETECTOR_PLOT_FORMATS = "detector",
@@ -2125,7 +2124,7 @@ class EBSDDetector:
         ----------
         inplace
             Whether the interactive changes affect the detector inplace.
-            Default is False.
+            Default is True.
         annotate
             Whether to annotate the side-view components. Default is
             False.

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -66,6 +66,9 @@ if TYPE_CHECKING:  # pragma: no cover
     if dependency_version["pyebsdindex"] is not None:
         from pyebsdindex.ebsd_index import EBSDIndexer
 
+    if dependency_version["ipywidgets"] is not None:
+        import ipywidgets as widgets
+
 
 PC_CONVENTIONS = Literal[
     "bruker",
@@ -1785,13 +1788,12 @@ class EBSDDetector:
         annotate: bool = False,
         dimensionless: bool = True,
         return_figure: bool = False,
+        **kwargs,
     ) -> "mfigure.Figure | mfigure.SubFigure | None":
         """Plot the EBSD detector-sample geometry in a 2D side-view.
 
         Parameters
         ----------
-        detector
-            EBSD detector.
         ax
             The Matplotlib axis to plot in. If not given, a new figure
             and axis are created.
@@ -1821,6 +1823,66 @@ class EBSDDetector:
 
         if return_figure:
             return fig
+
+    def plot_side_view_interactive(
+        self,
+        inplace: bool = False,
+        ax: "maxes.Axes | None" = None,
+        annotate: bool = False,
+        dimensionless: bool = True,
+        **kwargs,
+    ) -> "widgets.VBox":
+        """Plot the EBSD detector-sample geometry in a 2D side-view
+        with controls for changing the sample and detector tilts and the
+        projection center coordinates.
+
+        Parameters
+        ----------
+        inplace
+            Whether the interactive changes affect the detector inplace.
+            Default is False.
+        ax
+            The Matplotlib axis to plot in. If not given, a new figure
+            and axis are created.
+        annotate
+            Whether to annotate the various components of the geometry.
+            Default is False.
+        dimensionless
+            Whether to ignore the
+            :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
+            drawing the plot axes. Default is True.
+        **kwargs
+            Keyword arguments passed to
+            :func:`~matplotlib.pyplot.figure` if *ax* is not given.
+
+        Returns
+        -------
+        widgets
+            The widget containing the sliders. Required to display the
+            interactive controls.
+
+        See Also
+        --------
+        plot_side_view
+
+        Notes
+        -----
+        Requires that :mod:`ipywidgets` is installed.
+        """
+        from kikuchipy.draw._plot_ebsd_detector import (
+            plot_ebsd_detector_geometry_side_view_interactive,
+        )
+
+        widgets = plot_ebsd_detector_geometry_side_view_interactive(
+            detector=self,
+            inplace=inplace,
+            ax=ax,
+            annotate=annotate,
+            dimensionless=dimensionless,
+            **kwargs,
+        )
+
+        return widgets
 
     @overload
     def plot_pc(

--- a/src/kikuchipy/detectors/_fit_projection_center.py
+++ b/src/kikuchipy/detectors/_fit_projection_center.py
@@ -33,6 +33,7 @@ from skimage.transform import ProjectiveTransform
 from sklearn.linear_model import LinearRegression, RANSACRegressor
 
 from kikuchipy._constants import dependency_version
+from kikuchipy.detectors._ebsd_detector import EBSDDetector
 
 _logger = logging.getLogger(__name__)
 
@@ -78,13 +79,15 @@ def fit_hyperplane(
 
 
 def fit_plane_to_pc(
-    n_pc: int,
-    pc_flat: np.ndarray,
+    detector: EBSDDetector,
     pc_indices: np.ndarray,
     map_indices: np.ndarray,
     is_outlier: np.ndarray | None,
     transformation: Literal["projective", "affine"],
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, float, float]:
+    n_pc = detector.navigation_size
+    pc_flat = detector.pc_flattened
+
     # Prepare PCs and PC map indices for fitting
     pc_indices_flat = pc_indices.reshape((2, -1)).T
     pc_indices_flat = np.column_stack((pc_indices_flat, np.ones(n_pc)))
@@ -187,28 +190,34 @@ def fit_pc_affine(
     return pc_fit, pc_fit_map
 
 
-def estimate_xtilt_linear(
-    pcy: np.ndarray, pcz: np.ndarray
-) -> tuple[float, LinearRegression]:
+def estimate_xtilt_linear(detector: EBSDDetector) -> tuple[float, LinearRegression]:
     """Return an estimated X tilt from (PCy, PCz) using a linear model."""
+    pcy = detector.pcy.reshape((-1, 1))
+    pcz = detector.pcz.reshape((-1, 1))
+
     regressor = LinearRegression()
     regressor.fit(pcz, pcy)
     slope = regressor.coef_
     slope = slope.squeeze()
     x_tilt = float(np.pi / 2 + np.arctan(slope))
+
     return x_tilt, regressor
 
 
 def estimate_xtilt_linear_robust(
-    pcy: np.ndarray, pcz: np.ndarray
+    detector: EBSDDetector,
 ) -> tuple[float, RANSACRegressor, np.ndarray]:
     """Return an estimated X tilt from (PCy, PCz) using a robust linear
     model with detection of outliers.
     """
+    pcy = detector.pcy.reshape((-1, 1))
+    pcz = detector.pcz.reshape((-1, 1))
+
     regressor = RANSACRegressor()
     regressor.fit(pcz, pcy)
     slope = regressor.estimator_.coef_
     slope = slope.squeeze()
     x_tilt = float(np.pi / 2 + np.arctan(slope))
     is_outlier = ~regressor.inlier_mask_
+
     return x_tilt, regressor, is_outlier

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -19,7 +19,7 @@
 
 """Plotting an EBSD detector and projection centers."""
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import matplotlib.axes as maxes
 import matplotlib.figure as mfigure
@@ -30,7 +30,12 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 
+from kikuchipy._constants import dependency_version
 from kikuchipy.detectors._ebsd_detector import EBSDDetector
+
+if TYPE_CHECKING:
+    if dependency_version["ipywidgets"] is not None:
+        import ipywidgets as widgets
 
 DETECTOR_PLOT_FORMATS = Literal["detector", "gnomonic"]
 PROJECTION_CENTER_PLOT_MODES = Literal["map", "scatter", "3d"]
@@ -353,7 +358,9 @@ def plot_ebsd_detector_geometry_side_view(
     function.
     """
     if ax is None:
+        w, h = plt.rcParams["figure.figsize"]
         kwargs.setdefault("layout", "constrained")
+        kwargs.setdefault("figsize", (w, h))
         fig = plt.figure(**kwargs)
         ax = fig.add_subplot()
     else:
@@ -497,3 +504,134 @@ def plot_ebsd_detector_geometry_side_view(
         ax.set_ylabel(f"Microscope Z axis [{unit}]")
 
     return fig
+
+
+def plot_ebsd_detector_geometry_side_view_interactive(
+    detector: EBSDDetector,
+    inplace: bool = False,
+    ax: maxes.Axes | None = None,
+    annotate: bool = False,
+    dimensionless: bool = True,
+    **kwargs,
+) -> "widgets.VBox":
+    """Plot an interactive EBSD detector geometry side view.
+
+    The plot allows interactive modification of the detector and sample
+    tilts and the projection center (PC) values.
+
+    Parameters
+    ----------
+    detector
+        EBSD detector.
+    inplace
+        Whether to edit the given *detector* inplace. The given detector
+        is not affected by default.
+    ax
+        The Matplotlib axis to plot in. If not given, a new figure
+        and axis are created.
+    annotate
+        Whether to annotate the various components of the geometry.
+        Default is False.
+    dimensionless
+        Whether to ignore the
+        :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
+        drawing the plot axes. Default is True.
+    **kwargs
+        Keyword arguments passed to
+        :func:`~matplotlib.pyplot.figure` if *ax* is not given.
+
+    Returns
+    -------
+    widgets
+        The widget containing the sliders. Required to display the
+        interactive controls.
+
+    Notes
+    -----
+    Requires that :mod:`ipywidgets` is installed.
+    """
+    if dependency_version["ipywidgets"] is None:
+        raise ImportError("Requires that ipywidgets is installed")
+    if dependency_version["IPython"] is None:
+        raise ImportError("Requires that IPython is installed")
+
+    import ipywidgets as widgets
+
+    if inplace:
+        det = detector
+    else:
+        det = detector.deepcopy()
+    pcx, pcy, pcz = det.pc_average
+    det.pc = [pcx, pcy, pcz]
+
+    if ax is None:
+        w, h = plt.rcParams["figure.figsize"]
+        kwargs.setdefault("layout", "constrained")
+        kwargs.setdefault("figsize", (w, h))
+        fig = plt.figure(**kwargs)
+        ax = fig.add_subplot()
+    else:
+        fig = ax.figure
+
+    def get_range(val, default_range):
+        vmin, vmax = default_range
+        margin = max((vmax - vmin) * 0.1, 0.1)
+        if val < vmin:
+            vmin = val - margin
+        if val > vmax:
+            vmax = val + margin
+        return vmin, vmax
+
+    px_min, px_max = get_range(pcx, (0, 1))
+    py_min, py_max = get_range(pcy, (0, 1))
+    pz_min, pz_max = get_range(pcz, (0, 1))
+
+    style = {"description_width": "initial"}
+    s_st = widgets.FloatSlider(
+        value=det.sample_tilt,
+        min=0,
+        max=180,
+        step=0.1,
+        description="Sample tilt",
+        style=style,
+    )
+    s_dt = widgets.FloatSlider(
+        value=det.tilt,
+        min=0,
+        max=180,
+        step=0.1,
+        description="Detector tilt",
+        style=style,
+    )
+    s_px = widgets.FloatSlider(
+        value=pcx, min=px_min, max=px_max, step=0.01, description="PCx", style=style
+    )
+    s_py = widgets.FloatSlider(
+        value=pcy, min=py_min, max=py_max, step=0.01, description="PCy", style=style
+    )
+    s_pz = widgets.FloatSlider(
+        value=pcz, min=pz_min, max=pz_max, step=0.01, description="PCz", style=style
+    )
+
+    def update(change: Any = None) -> None:
+        det.sample_tilt = s_st.value
+        det.tilt = s_dt.value
+        det.pc = [s_px.value, s_py.value, s_pz.value]
+
+        # TODO: Look into blitting instead of clearing everything
+        ax.clear()
+
+        plot_ebsd_detector_geometry_side_view(
+            det, ax=ax, annotate=annotate, dimensionless=dimensionless
+        )
+
+        fig.canvas.draw_idle()
+
+    for s in [s_st, s_dt, s_px, s_py, s_pz]:
+        s.observe(update, names="value")
+
+    update()
+
+    widget = widgets.VBox([s_st, s_dt, s_px, s_py, s_pz])
+
+    return widget

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import matplotlib.axes as maxes
 import matplotlib.figure as mfigure
+import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -71,13 +72,13 @@ def plot_ebsd_detector(
         pcy *= sy - 1
         pcx *= sx - 1
         bounds[2:] = bounds[2:][::-1]
-        x_label = "x detector"
-        y_label = "y detector"
+        x_label = "Detector X"
+        y_label = "Detector Y"
     else:
         pcy, pcx = (0, 0)
         bounds = detector._average_gnomonic_bounds
-        x_label = "x gnomonic"
-        y_label = "y gnomonic"
+        x_label = "Gnomonic X"
+        y_label = "Gnomonic Y"
 
     fig, axis = set_up_figure_axis(ax=ax)
     axis.axis(zoom * bounds)
@@ -358,7 +359,7 @@ def plot_all_projection_centers_in_3d(
 def plot_detector_sample_geometry_side_view(
     detector: EBSDDetector,
     ax: maxes.Axes | None = None,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = False,
     **kwargs,
 ) -> mfigure.Figure | mfigure.SubFigure:
@@ -432,6 +433,15 @@ def plot_detector_sample_geometry_side_view(
         label="Sample",
         zorder=4,
     )
+    ax.scatter(
+        pc_pos[0],
+        pc_pos[1],
+        marker="+",
+        s=200,
+        fc=PC_COLOR,
+        label="PC",
+        zorder=5,
+    )
     ax.plot(
         [detector_start[0], detector_end[0]],
         [detector_start[1], detector_end[1]],
@@ -439,16 +449,6 @@ def plot_detector_sample_geometry_side_view(
         lw=4,
         label="Detector",
         zorder=4,
-    )
-    ax.plot(
-        pc_pos[0],
-        pc_pos[1],
-        marker="+",
-        ms=15,
-        mec=PC_COLOR,
-        linestyle="None",
-        label="PC",
-        zorder=5,
     )
     ax.plot(
         [source_pos[0], pc_pos[0]],
@@ -468,40 +468,11 @@ def plot_detector_sample_geometry_side_view(
     ax.set_xlim(pad, -pad)
     ax.set_ylim(-pad, pad)
 
-    if annotate:
-        ax.text(
-            beam_start[0],
-            beam_start[1],
-            "Beam",
-            ha="center",
-            va="bottom",
-            label="beam_annotation",
-        )
-        ax.text(
-            sample_start[0],
-            sample_start[1],
-            "Sample",
-            ha="right",
-            va="center",
-            label="sample_annotation",
-        )
-        ax.annotate(
-            "Detector",
-            xy=(detector_start[0], detector_start[1]),
-            xytext=(0, -12),
-            textcoords="offset points",
-            ha="center",
-            va="top",
-            label="detector_annotation",
-        )
-        ax.annotate(
-            "PC",
-            xy=(pc_pos[0], pc_pos[1]),
-            xytext=(5, 5),
-            textcoords="offset points",
-            ha="left",
-            va="bottom",
-            label="pc_annotation",
+    if legend:
+        beam_handle = mlines.Line2D([], [], color=BEAM_COLOR, label="Beam")
+        ax.legend(
+            handles=[beam_handle, *ax.get_legend_handles_labels()[0]],
+            loc="best",
         )
 
     if dimensionless:
@@ -519,20 +490,20 @@ def plot_detector_sample_geometry_side_view(
 def update_detector_sample_geometry_side_view(
     detector: EBSDDetector,
     ax: maxes.Axes,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = True,
 ) -> None:
     """Clear *ax* and redraw the side view for *detector*."""
     ax.clear()
     plot_detector_sample_geometry_side_view(
-        detector, ax=ax, annotate=annotate, dimensionless=dimensionless
+        detector, ax=ax, legend=legend, dimensionless=dimensionless
     )
 
 
 def plot_detector_sample_geometry_top_view(
     detector: EBSDDetector,
     ax: maxes.Axes | None = None,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = False,
     **kwargs,
 ) -> mfigure.Figure | mfigure.SubFigure:
@@ -577,12 +548,13 @@ def plot_detector_sample_geometry_top_view(
 
     to_mm = 1e-3
 
-    ax.plot(
+    ax.scatter(
         beam[0] * to_mm,
         beam[1] * to_mm,
         marker="o",
-        ms=8,
-        color=BEAM_COLOR,
+        s=70,
+        fc=BEAM_COLOR,
+        ec="k",
         zorder=5,
         label="Beam",
     )
@@ -594,6 +566,15 @@ def plot_detector_sample_geometry_top_view(
         label="Sample",
         zorder=4,
     )
+    ax.scatter(
+        pc_pos[0] * to_mm,
+        pc_pos[1] * to_mm,
+        marker="+",
+        s=200,
+        fc=PC_COLOR,
+        label="PC",
+        zorder=5,
+    )
     ax.plot(
         [det_left[0] * to_mm, det_right[0] * to_mm],
         [det_left[1] * to_mm, det_right[1] * to_mm],
@@ -601,16 +582,6 @@ def plot_detector_sample_geometry_top_view(
         lw=4,
         label="Detector",
         zorder=4,
-    )
-    ax.plot(
-        pc_pos[0] * to_mm,
-        pc_pos[1] * to_mm,
-        marker="+",
-        ms=15,
-        mec=PC_COLOR,
-        linestyle="None",
-        label="PC",
-        zorder=5,
     )
     ax.plot(
         [beam[0] * to_mm, pc_pos[0] * to_mm],
@@ -628,41 +599,8 @@ def plot_detector_sample_geometry_top_view(
     ax.set_xlim(pad, -pad)
     ax.set_ylim(pad, -pad)
 
-    if annotate:
-        ax.text(
-            beam[0] * to_mm,
-            beam[1] * to_mm,
-            " Beam",
-            ha="left",
-            va="bottom",
-            label="beam_annotation",
-        )
-        ax.text(
-            sample_end[0] * to_mm,
-            sample_end[1] * to_mm,
-            " Sample",
-            ha="left",
-            va="center",
-            label="sample_annotation",
-        )
-        ax.annotate(
-            "Detector",
-            xy=(pc_pos[0] * to_mm, pc_pos[1] * to_mm),
-            xytext=(0, -12),
-            textcoords="offset points",
-            ha="center",
-            va="top",
-            label="detector_annotation",
-        )
-        ax.annotate(
-            "PC",
-            xy=(pc_pos[0] * to_mm, pc_pos[1] * to_mm),
-            xytext=(5, 5),
-            textcoords="offset points",
-            ha="left",
-            va="bottom",
-            label="pc_annotation",
-        )
+    if legend:
+        ax.legend(loc="best")
 
     if dimensionless:
         ax.xaxis.set_ticks([])
@@ -670,8 +608,8 @@ def plot_detector_sample_geometry_top_view(
         unit = ""
     else:
         unit = " [mm]"
-    ax.set_xlabel(f"x microscope{unit}")
-    ax.set_ylabel(f"y microscope{unit}")
+    ax.set_xlabel(f"Microscope X{unit}")
+    ax.set_ylabel(f"Microscope Y{unit}")
 
     return fig
 
@@ -688,13 +626,13 @@ def get_axis_limit_pad(width: float) -> float:
 def update_detector_sample_geometry_top_view(
     detector: EBSDDetector,
     ax: maxes.Axes,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = True,
 ) -> None:
     """Clear *ax* and redraw the top view for *detector*."""
     ax.clear()
     plot_detector_sample_geometry_top_view(
-        detector, ax=ax, annotate=annotate, dimensionless=dimensionless
+        detector, ax=ax, legend=legend, dimensionless=dimensionless
     )
 
 
@@ -724,7 +662,7 @@ def update_detector_plane(
 def plot_detector_sample_geometry_side_view_interactive(
     detector: EBSDDetector,
     ax: maxes.Axes | None = None,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = True,
     **kwargs,
 ) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]":
@@ -740,13 +678,11 @@ def plot_detector_sample_geometry_side_view_interactive(
     detector.pc = detector.pc_average
     sample_tilt_slider = get_sample_tilt_slider(detector)
     detector_tilt_slider = get_detector_tilt_slider(detector)
-    azimuthal_slider = get_detector_azimuthal_slider(detector)
     pcy_slider = get_pcy_slider(detector)
     pcz_slider = get_pcz_slider(detector)
     sliders = [
         sample_tilt_slider,
         detector_tilt_slider,
-        azimuthal_slider,
         pcy_slider,
         pcz_slider,
     ]
@@ -756,22 +692,17 @@ def plot_detector_sample_geometry_side_view_interactive(
 
     def redraw(*args: Any) -> None:
         update_detector_sample_geometry_side_view(
-            detector, ax, annotate=annotate, dimensionless=dimensionless
+            detector, ax, legend=legend, dimensionless=dimensionless
         )
         fig.canvas.draw_idle()
 
     def update_detector_from_sliders():
         detector.sample_tilt = sample_tilt_slider.value
         detector.tilt = detector_tilt_slider.value
-        detector.azimuthal = azimuthal_slider.value
         detector.pcy = pcy_slider.value
         detector.pcz = pcz_slider.value
 
     if detector._has_signals:
-        detector._sample_tilt_changed.connect(redraw)
-        detector._tilt_changed.connect(redraw)
-        detector._azimuthal_changed.connect(redraw)
-        detector._pc_changed.connect(redraw)
 
         def on_slider_change(change: Any = None) -> None:
             # Block to redraw only once
@@ -802,7 +733,7 @@ def plot_detector_sample_geometry_side_view_interactive(
 def plot_detector_sample_geometry_top_view_interactive(
     detector: EBSDDetector,
     ax: maxes.Axes | None = None,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = True,
     **kwargs,
 ) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]":
@@ -830,7 +761,7 @@ def plot_detector_sample_geometry_top_view_interactive(
 
     def redraw(*args: Any) -> None:
         update_detector_sample_geometry_top_view(
-            detector, ax, annotate=annotate, dimensionless=dimensionless
+            detector, ax, legend=legend, dimensionless=dimensionless
         )
         fig.canvas.draw_idle()
 
@@ -870,7 +801,7 @@ def plot_detector_sample_geometry_top_view_interactive(
 def plot_detector_sample_geometry_interactive(
     detector: EBSDDetector,
     inplace: bool = False,
-    annotate: bool = False,
+    legend: bool = False,
     dimensionless: bool = True,
     coords_fmt: DETECTOR_PLOT_FORMATS = "detector",
     zoom: float = 1.0,
@@ -886,9 +817,9 @@ def plot_detector_sample_geometry_interactive(
     inplace
         Whether to edit the given *detector* inplace. The given detector
         is not affected by default.
-    annotate
-        Whether to annotate the side-view components.
-        Default is False.
+    legend
+        Whether to show a legend in the upper right corner of the side
+        and top view plots. Default is False.
     dimensionless
         Whether to ignore
         :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
@@ -948,13 +879,13 @@ def plot_detector_sample_geometry_interactive(
 
     def redraw_side(*args: Any) -> None:
         update_detector_sample_geometry_side_view(
-            det, ax_side, annotate=annotate, dimensionless=dimensionless
+            det, ax_side, legend=legend, dimensionless=dimensionless
         )
         ax_side.set_title("Side view")
 
     def redraw_top(*args: Any) -> None:
         update_detector_sample_geometry_top_view(
-            det, ax_top, annotate=annotate, dimensionless=dimensionless
+            det, ax_top, legend=legend, dimensionless=dimensionless
         )
         ax_top.set_title("Top view")
 

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import matplotlib.axes as maxes
 import matplotlib.figure as mfigure
-from matplotlib.markers import MarkerStyle
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -40,6 +39,11 @@ if TYPE_CHECKING:
 # Repeated in detector module
 DETECTOR_PLOT_FORMATS = Literal["detector", "gnomonic"]
 PROJECTION_CENTER_PLOT_MODES = Literal["map", "scatter", "3d"]
+
+BEAM_COLOR = "C2"
+SAMPLE_COLOR = "C0"
+PC_COLOR = "C1"
+DETECTOR_COLOR = "C7"
 
 
 def plot_ebsd_detector(
@@ -89,18 +93,16 @@ def plot_ebsd_detector(
         width = np.diff(bounds[:2])[0]
         height = np.diff(bounds[2:])[0]
         ax.add_artist(
-            mpatches.Rectangle(origin, width, height, fc=(0.5,) * 3, zorder=-1)
+            mpatches.Rectangle(origin, width, height, fc=DETECTOR_COLOR, zorder=-1)
         )
 
-    # Show the projection center
     if show_pc:
-        default_params_pc = dict(
-            s=300,
-            facecolor="gold",
-            edgecolor="k",
-            marker=MarkerStyle(marker="*", fillstyle="full"),
-            zorder=10,
-        )
+        default_params_pc = {
+            "s": 300,
+            "facecolor": PC_COLOR,
+            "marker": "+",
+            "zorder": 10,
+        }
         for k, v in default_params_pc.items():
             pc_kwargs.setdefault(k, v)
         ax.scatter(x=pcx, y=pcy, **pc_kwargs)
@@ -358,31 +360,38 @@ def plot_ebsd_detector_geometry_side_view(
 ) -> mfigure.Figure | mfigure.SubFigure:
     """See the docstring of the EBSD detector method using this
     function.
+
+    Coordinates are calculated in microns relative to the beam-sample
+    interaction volume (0, 0).
+
+    The figure plane is given by the microscope reference frame: Y west
+    and Z north. Coordinates for elements are transformed to this
+    reference frame after they are defined.
+
+    See the docstring of the EBSD detector method using this function
+    for further details.
     """
     fig, ax = set_up_figure_axis(ax=ax, **kwargs)
 
-    # Dimensions in microns
+    # Dimensions in mm and angles in radians
     height = detector.height
     L = detector.specimen_scintillator_distance[0]
     beam_length = L * 0.5
-    sample_length = L * 1.5
-
-    # Coordinates are calculated in microns relative to the beam-sample
-    # interaction volume (0, 0)
-
-    # Electron beam
-    beam_start = np.array([0, -beam_length], dtype=np.float64)
-    beam_end = np.zeros(2, dtype=np.float64)
-
-    # Sample surface
+    half_sample_length = (L * 1.5) / 2
     sigma = np.deg2rad(detector.sample_tilt)
-    dx_sample = (sample_length / 2) * np.cos(sigma)
-    dz_sample = (sample_length / 2) * np.sin(sigma)
-    sample_start = np.array([-dx_sample, -dz_sample])
-    sample_end = np.array([dx_sample, dz_sample])
-
-    # Detector screen (Z = normal, Y = down)
     theta = np.deg2rad(detector.tilt)
+
+    # Beam
+    beam_end = np.zeros(2, dtype=np.float64)
+    beam_start = np.array([0, -beam_length], dtype=np.float64)
+
+    # Sample
+    dx_sample = half_sample_length * np.cos(sigma)
+    dy_sample = half_sample_length * np.sin(sigma)
+    sample_end = np.array([dx_sample, dy_sample], dtype=np.float64)
+    sample_start = -sample_end
+
+    # Detector screen
     detector_z = np.array([np.cos(theta), np.sin(theta)])
     P = L * detector_z
     detector_y = np.array([-np.sin(theta), np.cos(theta)])
@@ -392,9 +401,11 @@ def plot_ebsd_detector_geometry_side_view(
     screen_top = P - pcy * height * detector_y
     screen_bottom = P + (1 - pcy) * detector.height * detector_y
 
-    # Shift coordinates to top left corner of detector and convert to mm
-    def trans(point):
-        return (point - screen_top) * 1e-3
+    # Negate Z so the Z axis points upward (opposite beam direction)
+    def trans(point: np.ndarray) -> np.ndarray:
+        p = point * 1e-3
+        p[1] = -p[1]
+        return p
 
     beam_start = trans(beam_start)
     beam_end = trans(beam_end)
@@ -405,18 +416,17 @@ def plot_ebsd_detector_geometry_side_view(
     pc_pos = trans(P)
     source_pos = trans(np.zeros(2, dtype=np.float64))
 
-    beam_color = "#c4761c"
     ax.annotate(
         "",
         xy=beam_end,
         xytext=beam_start,
-        arrowprops={"arrowstyle": "->", "lw": 2, "color": beam_color},
+        arrowprops={"arrowstyle": "->", "lw": 2, "color": BEAM_COLOR},
         zorder=5,
     )
     ax.plot(
         [sample_start[0], sample_end[0]],
         [sample_start[1], sample_end[1]],
-        c="gray",
+        c=SAMPLE_COLOR,
         lw=3,
         label="Sample",
         zorder=4,
@@ -424,7 +434,7 @@ def plot_ebsd_detector_geometry_side_view(
     ax.plot(
         [detector_start[0], detector_end[0]],
         [detector_start[1], detector_end[1]],
-        c="purple",
+        c=DETECTOR_COLOR,
         lw=4,
         label="Detector",
         zorder=4,
@@ -432,10 +442,9 @@ def plot_ebsd_detector_geometry_side_view(
     ax.plot(
         pc_pos[0],
         pc_pos[1],
-        marker="*",
+        marker="+",
         ms=15,
-        mfc="gold",
-        mec="k",
+        mec=PC_COLOR,
         linestyle="None",
         label="PC",
         zorder=5,
@@ -444,15 +453,14 @@ def plot_ebsd_detector_geometry_side_view(
         [source_pos[0], pc_pos[0]],
         [source_pos[1], pc_pos[1]],
         linestyle=":",
-        color=beam_color,
+        color=BEAM_COLOR,
         alpha=0.5,
         zorder=0,
     )
 
-    # Handle axis orientation: Y axis as x-coordinate, Z as
-    # y-coordinate, Z pointing down
+    # Handle axis orientation: Y axis as x-coordinate (inverted so
+    # detector appears on the left), Z as y-coordinate pointing up
     ax.set_aspect("equal")
-    ax.invert_yaxis()
     ax.invert_xaxis()
 
     if annotate:
@@ -466,7 +474,7 @@ def plot_ebsd_detector_geometry_side_view(
         )
         ax.text(
             sample_start[0],
-            sample_end[1],
+            sample_start[1],
             "Sample",
             ha="right",
             va="center",
@@ -475,7 +483,7 @@ def plot_ebsd_detector_geometry_side_view(
         ax.annotate(
             "Detector",
             xy=(detector_start[0], detector_start[1]),
-            xytext=(0, 12),
+            xytext=(0, -12),
             textcoords="offset points",
             ha="center",
             va="top",
@@ -484,19 +492,21 @@ def plot_ebsd_detector_geometry_side_view(
         ax.annotate(
             "PC",
             xy=(pc_pos[0], pc_pos[1]),
-            xytext=(5, -5),
+            xytext=(5, 5),
             textcoords="offset points",
             ha="left",
-            va="top",
+            va="bottom",
             label="pc_annotation",
         )
 
     if dimensionless:
-        ax.axis("off")
+        ax.xaxis.set_ticks([])
+        ax.yaxis.set_ticks([])
+        unit = ""
     else:
-        unit = "mm"
-        ax.set_xlabel(f"Microscope Y axis [{unit}]")
-        ax.set_ylabel(f"Microscope Z axis [{unit}]")
+        unit = " [mm]"
+    ax.set_xlabel(f"y microscope{unit}")
+    ax.set_ylabel(f"z microscope{unit}")
 
     return fig
 
@@ -510,6 +520,169 @@ def update_side_view(
     """Clear *ax* and redraw the side view for *detector*."""
     ax.clear()
     plot_ebsd_detector_geometry_side_view(
+        detector, ax=ax, annotate=annotate, dimensionless=dimensionless
+    )
+
+
+def plot_ebsd_detector_geometry_top_view(
+    detector: EBSDDetector,
+    ax: maxes.Axes | None = None,
+    annotate: bool = False,
+    dimensionless: bool = False,
+    **kwargs,
+) -> mfigure.Figure | mfigure.SubFigure:
+    r"""Plot the EBSD detector-sample geometry in a 2D top-view.
+
+    Coordinates are calculated in microns relative to the beam-sample
+    interaction volume (0, 0).
+
+    The figure plane is given by the microscope reference frame: x west
+    and y south. Coordinates for elements are transformed to this
+    reference frame after they are defined.
+
+    See the docstring of the EBSD detector method using this function
+    for further details.
+    """
+    fig, ax = set_up_figure_axis(ax=ax, **kwargs)
+
+    # Dimensions in microns and angles in radians
+    width = detector.width
+    L = detector.specimen_scintillator_distance[0]
+    sample_length = L * 1.5
+    azimuthal = np.deg2rad(detector.azimuthal)
+    theta = np.deg2rad(detector.tilt)
+
+    beam = np.zeros(2)
+
+    # Sample-detector distance (shortened by the detector tilt)
+    d = L * np.cos(theta)
+
+    # PC in microscope X-Y coordinates, with the screen normal pointing
+    # towards the interaction volume
+    det_normal = np.array([np.sin(azimuthal), np.cos(azimuthal)])
+    pc_pos = d * det_normal
+
+    # Unit vector along the detector width, perpendicular to the normal
+    width_dir = np.array([-np.cos(azimuthal), np.sin(azimuthal)])
+
+    # Detector endpoints
+    pcx = detector.pc_average[0]
+    left_extent = pcx * width
+    right_extent = (1 - pcx) * width
+    det_left = pc_pos - left_extent * width_dir
+    det_right = pc_pos + right_extent * width_dir
+
+    # Sample surface: a line along X at Y=0
+    sample_start = np.array([-sample_length / 2, 0])
+    sample_end = np.array([sample_length / 2, 0])
+
+    to_mm = 1e-3
+
+    ax.plot(
+        beam[0] * to_mm,
+        beam[1] * to_mm,
+        marker="o",
+        ms=8,
+        color=BEAM_COLOR,
+        zorder=5,
+        label="Beam",
+    )
+    ax.plot(
+        [sample_start[0] * to_mm, sample_end[0] * to_mm],
+        [sample_start[1] * to_mm, sample_end[1] * to_mm],
+        c=SAMPLE_COLOR,
+        lw=3,
+        label="Sample",
+        zorder=4,
+    )
+    ax.plot(
+        [det_left[0] * to_mm, det_right[0] * to_mm],
+        [det_left[1] * to_mm, det_right[1] * to_mm],
+        c=DETECTOR_COLOR,
+        lw=4,
+        label="Detector",
+        zorder=4,
+    )
+    ax.plot(
+        pc_pos[0] * to_mm,
+        pc_pos[1] * to_mm,
+        marker="+",
+        ms=15,
+        mec=PC_COLOR,
+        linestyle="None",
+        label="PC",
+        zorder=5,
+    )
+    ax.plot(
+        [beam[0] * to_mm, pc_pos[0] * to_mm],
+        [beam[1] * to_mm, pc_pos[1] * to_mm],
+        linestyle=":",
+        color=BEAM_COLOR,
+        alpha=0.5,
+        zorder=0,
+    )
+
+    ax.set_aspect("equal")
+    ax.invert_yaxis()
+    ax.invert_xaxis()
+
+    if annotate:
+        ax.text(
+            beam[0] * to_mm,
+            beam[1] * to_mm,
+            " Beam",
+            ha="left",
+            va="bottom",
+            label="beam_annotation",
+        )
+        ax.text(
+            sample_end[0] * to_mm,
+            sample_end[1] * to_mm,
+            " Sample",
+            ha="left",
+            va="center",
+            label="sample_annotation",
+        )
+        ax.annotate(
+            "Detector",
+            xy=(pc_pos[0] * to_mm, pc_pos[1] * to_mm),
+            xytext=(0, -12),
+            textcoords="offset points",
+            ha="center",
+            va="top",
+            label="detector_annotation",
+        )
+        ax.annotate(
+            "PC",
+            xy=(pc_pos[0] * to_mm, pc_pos[1] * to_mm),
+            xytext=(5, 5),
+            textcoords="offset points",
+            ha="left",
+            va="bottom",
+            label="pc_annotation",
+        )
+
+    if dimensionless:
+        ax.xaxis.set_ticks([])
+        ax.yaxis.set_ticks([])
+        unit = ""
+    else:
+        unit = " [mm]"
+    ax.set_xlabel(f"x microscope{unit}")
+    ax.set_ylabel(f"y microscope{unit}")
+
+    return fig
+
+
+def update_top_view(
+    detector: EBSDDetector,
+    ax: maxes.Axes,
+    annotate: bool = False,
+    dimensionless: bool = True,
+) -> None:
+    """Clear *ax* and redraw the top view for *detector*."""
+    ax.clear()
+    plot_ebsd_detector_geometry_top_view(
         detector, ax=ax, annotate=annotate, dimensionless=dimensionless
     )
 
@@ -598,6 +771,7 @@ def plot_ebsd_detector_geometry_side_view_interactive(
     det.pc = [pcx, pcy, pcz]
 
     fig, ax = set_up_figure_axis(ax=ax, **kwargs)
+    ax.set_title("Side view")
 
     sliders = make_detector_sliders(det)
 
@@ -605,36 +779,31 @@ def plot_ebsd_detector_geometry_side_view_interactive(
         update_side_view(det, ax, annotate=annotate, dimensionless=dimensionless)
         fig.canvas.draw_idle()
 
+    def update_detector_from_sliders():
+        det.sample_tilt = sliders["sample_tilt"].value
+        det.tilt = sliders["tilt"].value
+        det.azimuthal = sliders["azimuthal"].value
+        det.pc = [sliders["pcx"].value, sliders["pcy"].value, sliders["pcz"].value]
+
     if det._has_signals:
         det._sample_tilt_changed.connect(redraw)
         det._tilt_changed.connect(redraw)
+        det._azimuthal_changed.connect(redraw)
         det._pc_changed.connect(redraw)
 
         def on_slider_change(change: Any = None) -> None:
-            # Block signals while setting all values to avoid multiple
-            # redraws, then emit manually once
+            # Block to redraw only once
             with (
                 det._sample_tilt_changed.blocked(),
                 det._tilt_changed.blocked(),
+                det._azimuthal_changed.blocked(),
                 det._pc_changed.blocked(),
             ):
-                det.sample_tilt = sliders["sample_tilt"].value
-                det.tilt = sliders["tilt"].value
-                det.pc = [
-                    sliders["pcx"].value,
-                    sliders["pcy"].value,
-                    sliders["pcz"].value,
-                ]
+                update_detector_from_sliders()
     else:
 
         def on_slider_change(change: Any = None) -> None:
-            det.sample_tilt = sliders["sample_tilt"].value
-            det.tilt = sliders["tilt"].value
-            det.pc = [
-                sliders["pcx"].value,
-                sliders["pcy"].value,
-                sliders["pcz"].value,
-            ]
+            update_detector_from_sliders()
             redraw()
 
     for s in sliders.values():
@@ -656,8 +825,8 @@ def plot_ebsd_detector_combined_interactive(
     zoom: float = 1.0,
     **kwargs,
 ) -> "tuple[mfigure.Figure, ipywidgets.VBox]":
-    """Plot the side view and detector plane side by side with
-    interactive controls.
+    """Plot the side view, top view, and detector plane side by side
+    with interactive controls.
 
     Parameters
     ----------
@@ -708,29 +877,47 @@ def plot_ebsd_detector_combined_interactive(
 
     w, h = plt.rcParams["figure.figsize"]
     kwargs.setdefault("layout", "constrained")
-    kwargs.setdefault("figsize", (2 * w, h))
+    kwargs.setdefault("figsize", (3 * w, h))
     fig = plt.figure(**kwargs)
-    ax_side, ax_det = fig.subplots(1, 2)
+    ax_side, ax_top, ax_det = fig.subplots(1, 3)
 
     sliders = make_detector_sliders(det)
 
     def redraw_side(*args: Any) -> None:
         update_side_view(det, ax_side, annotate=annotate, dimensionless=dimensionless)
+        ax_side.set_title("Side view")
+
+    def redraw_top(*args: Any) -> None:
+        update_top_view(det, ax_top, annotate=annotate, dimensionless=dimensionless)
+        ax_top.set_title("Top view")
 
     def redraw_det(*args: Any) -> None:
         update_detector_plane(det, ax_det, coords_fmt=coords_fmt, zoom=zoom)
+        ax_det.set_title("Detector")
 
     def redraw_all() -> None:
         redraw_side()
+        redraw_top()
         redraw_det()
         fig.canvas.draw_idle()
 
+    def update_detector_from_sliders():
+        det.sample_tilt = sliders["sample_tilt"].value
+        det.tilt = sliders["tilt"].value
+        det.azimuthal = sliders["azimuthal"].value
+        det.pc = [sliders["pcx"].value, sliders["pcy"].value, sliders["pcz"].value]
+
     if det._has_signals:
         det._sample_tilt_changed.connect(redraw_side)
+        det._sample_tilt_changed.connect(redraw_top)
         det._sample_tilt_changed.connect(lambda *a: fig.canvas.draw_idle())
         det._tilt_changed.connect(redraw_side)
+        det._tilt_changed.connect(redraw_top)
         det._tilt_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._azimuthal_changed.connect(redraw_top)
+        det._azimuthal_changed.connect(lambda *a: fig.canvas.draw_idle())
         det._pc_changed.connect(redraw_side)
+        det._pc_changed.connect(redraw_top)
         det._pc_changed.connect(redraw_det)
         det._pc_changed.connect(lambda *a: fig.canvas.draw_idle())
 
@@ -738,26 +925,15 @@ def plot_ebsd_detector_combined_interactive(
             with (
                 det._sample_tilt_changed.blocked(),
                 det._tilt_changed.blocked(),
+                det._azimuthal_changed.blocked(),
                 det._pc_changed.blocked(),
             ):
-                det.sample_tilt = sliders["sample_tilt"].value
-                det.tilt = sliders["tilt"].value
-                det.pc = [
-                    sliders["pcx"].value,
-                    sliders["pcy"].value,
-                    sliders["pcz"].value,
-                ]
+                update_detector_from_sliders()
             redraw_all()
     else:
 
         def on_slider_change(change: Any = None) -> None:
-            det.sample_tilt = sliders["sample_tilt"].value
-            det.tilt = sliders["tilt"].value
-            det.pc = [
-                sliders["pcx"].value,
-                sliders["pcy"].value,
-                sliders["pcz"].value,
-            ]
+            update_detector_from_sliders()
             redraw_all()
 
     for s in sliders.values():
@@ -850,6 +1026,14 @@ def make_detector_sliders(
             max=pz_max,
             step=0.01,
             description="PCz",
+            style=style,
+        ),
+        "azimuthal": ipywidgets.FloatSlider(
+            value=detector.azimuthal,
+            min=-180,
+            max=180,
+            step=0.1,
+            description="Azimuthal",
             style=style,
         ),
     }

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -21,6 +21,7 @@
 
 from typing import Any, Literal
 
+import matplotlib.axes as maxes
 import matplotlib.figure as mfigure
 from matplotlib.markers import MarkerStyle
 import matplotlib.patches as mpatches
@@ -29,15 +30,14 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 
+from kikuchipy.detectors._ebsd_detector import EBSDDetector
+
 DETECTOR_PLOT_FORMATS = Literal["detector", "gnomonic"]
 PROJECTION_CENTER_PLOT_MODES = Literal["map", "scatter", "3d"]
 
 
 def plot_ebsd_detector(
-    shape: tuple[int, int],
-    pcxy: np.ndarray,
-    bounds: np.ndarray,
-    average_gnomonic_bounds: np.ndarray,
+    detector: EBSDDetector,
     coords_fmt: DETECTOR_PLOT_FORMATS,
     zoom: float,
     show_pc: bool,
@@ -48,19 +48,19 @@ def plot_ebsd_detector(
     gnomonic_circles_kwargs: dict,
     gnomonic_angles: np.ndarray | list | None,
 ) -> mfigure.Figure:
-    sy, sx = shape
-    pcx, pcy = pcxy
+    sy, sx = detector.shape
+    pcx, pcy = detector.pc_average[:2]
+    bounds = detector.bounds
 
     if coords_fmt == "detector":
         pcy *= sy - 1
         pcx *= sx - 1
-        bounds = bounds
         bounds[2:] = bounds[2:][::-1]
         x_label = "x detector"
         y_label = "y detector"
     else:
         pcy, pcx = (0, 0)
-        bounds = average_gnomonic_bounds
+        bounds = detector._average_gnomonic_bounds
         x_label = "x gnomonic"
         y_label = "y gnomonic"
 
@@ -338,5 +338,153 @@ def plot_all_projection_centers_in_3d(
     if annotate:
         for i, (x, z, y) in enumerate(zip(pcx, pcz, pcy)):
             ax.text(x, z, y, i)
+
+    return fig
+
+
+def plot_ebsd_detector_geometry_side_view(
+    detector: EBSDDetector,
+    ax: maxes.Axes | None = None,
+    annotate: bool = False,
+    dimensionless: bool = False,
+    **kwargs,
+) -> mfigure.Figure | mfigure.SubFigure:
+    """See the docstring of the EBSD detector method using this
+    function.
+    """
+    if ax is None:
+        kwargs.setdefault("layout", "constrained")
+        fig = plt.figure(**kwargs)
+        ax = fig.add_subplot()
+    else:
+        fig = ax.figure
+
+    # Dimensions in microns
+    height = detector.height
+    L = detector.specimen_scintillator_distance[0]
+    beam_length = L * 0.5
+    sample_length = L * 1.5
+
+    # Coordinates are calculated in microns relative to the beam-sample
+    # interaction volume (0, 0)
+
+    # Electron beam
+    beam_start = np.array([0, -beam_length], dtype=np.float64)
+    beam_end = np.zeros(2, dtype=np.float64)
+
+    # Sample surface
+    sigma = np.deg2rad(detector.sample_tilt)
+    dx_sample = (sample_length / 2) * np.cos(sigma)
+    dz_sample = (sample_length / 2) * np.sin(sigma)
+    sample_start = np.array([-dx_sample, -dz_sample])
+    sample_end = np.array([dx_sample, dz_sample])
+
+    # Detector screen (Z = normal, Y = down)
+    theta = np.deg2rad(detector.tilt)
+    detector_z = np.array([np.cos(theta), np.sin(theta)])
+    P = L * detector_z
+    detector_y = np.array([-np.sin(theta), np.cos(theta)])
+
+    # Screen extent
+    pcy = detector.pc_average[1]
+    screen_top = P - pcy * height * detector_y
+    screen_bottom = P + (1 - pcy) * detector.height * detector_y
+
+    # Shift coordinates to top left corner of detector and convert to mm
+    def trans(point):
+        return (point - screen_top) * 1e-3
+
+    beam_start = trans(beam_start)
+    beam_end = trans(beam_end)
+    sample_start = trans(sample_start)
+    sample_end = trans(sample_end)
+    detector_start = trans(screen_top)
+    detector_end = trans(screen_bottom)
+    pc_pos = trans(P)
+    source_pos = trans(np.zeros(2, dtype=np.float64))
+
+    beam_color = "#c4761c"
+    ax.annotate(
+        "",
+        xy=beam_end,
+        xytext=beam_start,
+        arrowprops={"arrowstyle": "->", "lw": 2, "color": beam_color},
+        zorder=5,
+    )
+    ax.plot(
+        [sample_start[0], sample_end[0]],
+        [sample_start[1], sample_end[1]],
+        c="gray",
+        lw=3,
+        label="Sample",
+        zorder=4,
+    )
+    ax.plot(
+        [detector_start[0], detector_end[0]],
+        [detector_start[1], detector_end[1]],
+        c="purple",
+        lw=4,
+        label="Detector",
+        zorder=4,
+    )
+    ax.plot(
+        pc_pos[0],
+        pc_pos[1],
+        marker="*",
+        ms=15,
+        mfc="gold",
+        mec="k",
+        linestyle="None",
+        label="PC",
+        zorder=5,
+    )
+    ax.plot(
+        [source_pos[0], pc_pos[0]],
+        [source_pos[1], pc_pos[1]],
+        linestyle=":",
+        color=beam_color,
+        alpha=0.5,
+        zorder=0,
+    )
+
+    ax.set_aspect("equal")
+
+    # Handle axis orientation: Y axis as x-coordinate, Z as
+    # y-coordinate, Z pointing down
+    ax.invert_yaxis()
+    ax.invert_xaxis()
+
+    if annotate:
+        ax.text(beam_start[0], beam_start[1], "Beam", ha="center", va="bottom")
+        ax.text(
+            sample_start[0],
+            sample_end[1],
+            "Sample",
+            ha="right",
+            va="center",
+        )
+        ax.annotate(
+            "Detector",
+            xy=(detector_start[0], detector_start[1]),
+            xytext=(0, 12),
+            textcoords="offset points",
+            ha="center",
+            va="top",
+        )
+        ax.annotate(
+            "PC",
+            xy=(pc_pos[0], pc_pos[1]),
+            xytext=(5, -5),
+            textcoords="offset points",
+            ha="left",
+            va="top",
+        )
+
+    if dimensionless:
+        ax.axis("off")
+    else:
+        unit = "mm"
+        ax.set_xlabel(f"Microscope Y axis [{unit}]")
+        ax.set_ylabel(f"Microscope Z axis [{unit}]")
 
     return fig

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -371,17 +371,14 @@ def plot_detector_sample_geometry_side_view(
     The figure plane is given by the microscope reference frame: Y west
     and Z north. Coordinates for elements are transformed to this
     reference frame after they are defined.
-
-    See the docstring of the EBSD detector method using this function
-    for further details.
     """
     fig, ax = set_up_figure_axis(ax=ax, **kwargs)
 
     # Dimensions in mm and angles in radians
     height = detector.height
     L = detector.specimen_scintillator_distance[0]
-    beam_length = L * 0.5
-    half_sample_length = (L * 1.5) / 2
+    beam_length = height * 0.5
+    half_sample_length = height * 0.3
     sigma = np.deg2rad(detector.sample_tilt)
     theta = np.deg2rad(detector.tilt)
 
@@ -431,7 +428,7 @@ def plot_detector_sample_geometry_side_view(
         [sample_start[0], sample_end[0]],
         [sample_start[1], sample_end[1]],
         c=SAMPLE_COLOR,
-        lw=3,
+        lw=6,
         label="Sample",
         zorder=4,
     )
@@ -465,7 +462,11 @@ def plot_detector_sample_geometry_side_view(
     # Handle axis orientation: Y axis as x-coordinate (inverted so
     # detector appears on the left), Z as y-coordinate pointing up
     ax.set_aspect("equal")
-    ax.invert_xaxis()
+
+    # Fix axis limits
+    pad = get_axis_limit_pad(height)
+    ax.set_xlim(pad, -pad)
+    ax.set_ylim(-pad, pad)
 
     if annotate:
         ax.text(
@@ -535,24 +536,22 @@ def plot_detector_sample_geometry_top_view(
     dimensionless: bool = False,
     **kwargs,
 ) -> mfigure.Figure | mfigure.SubFigure:
-    r"""Plot the EBSD detector-sample geometry in a 2D top-view.
+    """See the docstring of the EBSD detector method using this function
+    for further details.
 
     Coordinates are calculated in microns relative to the beam-sample
     interaction volume (0, 0).
 
-    The figure plane is given by the microscope reference frame: x west
-    and y south. Coordinates for elements are transformed to this
+    The figure plane is given by the microscope reference frame: X west
+    and Y south. Coordinates for elements are transformed to this
     reference frame after they are defined.
-
-    See the docstring of the EBSD detector method using this function
-    for further details.
     """
     fig, ax = set_up_figure_axis(ax=ax, **kwargs)
 
     # Dimensions in microns and angles in radians
     width = detector.width
     L = detector.specimen_scintillator_distance[0]
-    sample_length = L * 1.5
+    sample_length = width * 0.6
     azimuthal = np.deg2rad(detector.azimuthal)
 
     beam = np.zeros(2)
@@ -591,7 +590,7 @@ def plot_detector_sample_geometry_top_view(
         [sample_start[0] * to_mm, sample_end[0] * to_mm],
         [sample_start[1] * to_mm, sample_end[1] * to_mm],
         c=SAMPLE_COLOR,
-        lw=3,
+        lw=6,
         label="Sample",
         zorder=4,
     )
@@ -623,8 +622,11 @@ def plot_detector_sample_geometry_top_view(
     )
 
     ax.set_aspect("equal")
-    ax.invert_yaxis()
-    ax.invert_xaxis()
+
+    # Fix axis limits
+    pad = get_axis_limit_pad(width)
+    ax.set_xlim(pad, -pad)
+    ax.set_ylim(pad, -pad)
 
     if annotate:
         ax.text(
@@ -672,6 +674,15 @@ def plot_detector_sample_geometry_top_view(
     ax.set_ylabel(f"y microscope{unit}")
 
     return fig
+
+
+def get_axis_limit_pad(width: float) -> float:
+    """Return sufficient axis limits for the detector to move around
+    without moving outside the axis.
+    """
+    width_mm = width * 1e-3
+    pad = 1.1 * width_mm
+    return pad
 
 
 def update_detector_sample_geometry_top_view(
@@ -805,14 +816,10 @@ def plot_detector_sample_geometry_top_view_interactive(
     import ipywidgets
 
     detector.pc = detector.pc_average
-    sample_tilt_slider = get_sample_tilt_slider(detector)
-    detector_tilt_slider = get_detector_tilt_slider(detector)
     azimuthal_slider = get_detector_azimuthal_slider(detector)
     pcx_slider = get_pcx_slider(detector)
     pcz_slider = get_pcz_slider(detector)
     sliders = [
-        sample_tilt_slider,
-        detector_tilt_slider,
         azimuthal_slider,
         pcx_slider,
         pcz_slider,
@@ -822,29 +829,23 @@ def plot_detector_sample_geometry_top_view_interactive(
     ax.set_title("Top view")
 
     def redraw(*args: Any) -> None:
-        update_detector_sample_geometry_side_view(
+        update_detector_sample_geometry_top_view(
             detector, ax, annotate=annotate, dimensionless=dimensionless
         )
         fig.canvas.draw_idle()
 
     def update_detector_from_sliders():
-        detector.sample_tilt = sample_tilt_slider.value
-        detector.tilt = detector_tilt_slider.value
         detector.azimuthal = azimuthal_slider.value
         detector.pcx = pcx_slider.value
         detector.pcz = pcz_slider.value
 
     if detector._has_signals:
-        detector._sample_tilt_changed.connect(redraw)
-        detector._tilt_changed.connect(redraw)
         detector._azimuthal_changed.connect(redraw)
         detector._pc_changed.connect(redraw)
 
         def on_slider_change(change: Any = None) -> None:
             # Block to redraw only once
             with (
-                detector._sample_tilt_changed.blocked(),
-                detector._tilt_changed.blocked(),
                 detector._azimuthal_changed.blocked(),
                 detector._pc_changed.blocked(),
             ):
@@ -1026,9 +1027,10 @@ def set_up_figure_axis(
     return fig, ax
 
 
-def get_detector_value_in_range(
+def get_detector_value_range(
     value: float, vmin: float, vmax: float
 ) -> tuple[float, float]:
+    """Return an appropriate range containing *value*."""
     margin = max((vmax - vmin) * 0.1, 0.1)
     if value < vmin:
         vmin = value - margin
@@ -1047,11 +1049,14 @@ def get_sample_tilt_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
 
     import ipywidgets
 
+    stilt = detector.sample_tilt
+    stilt_min, stilt_max = get_detector_value_range(stilt, 0, 180)
+
     style = get_slider_style()
     widget = ipywidgets.FloatSlider(
-        value=detector.sample_tilt,
-        min=0,
-        max=180,
+        value=stilt,
+        min=stilt_min,
+        max=stilt_max,
         step=0.1,
         description="Sample tilt",
         style=style,
@@ -1066,11 +1071,14 @@ def get_detector_tilt_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider"
 
     import ipywidgets
 
+    tilt = detector.tilt
+    tilt_min, tilt_max = get_detector_value_range(tilt, 0, 180)
+
     style = get_slider_style()
     widget = ipywidgets.FloatSlider(
-        value=detector.tilt,
-        min=0,
-        max=180,
+        value=tilt,
+        min=tilt_min,
+        max=tilt_max,
         step=0.1,
         description="Detector tilt",
         style=style,
@@ -1085,12 +1093,15 @@ def get_detector_azimuthal_slider(detector: EBSDDetector) -> "ipywidgets.FloatSl
 
     import ipywidgets
 
+    azim = detector.azimuthal
+    azim_min, azim_max = get_detector_value_range(azim, -10, 10)
+
     style = get_slider_style()
     widget = ipywidgets.FloatSlider(
-        value=detector.azimuthal,
-        min=-180,
-        max=180,
-        step=0.1,
+        value=azim,
+        min=azim_min,
+        max=azim_max,
+        step=0.01,
         description="Azimuthal",
         style=style,
     )
@@ -1105,7 +1116,8 @@ def get_pcx_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
     import ipywidgets
 
     pcx = detector.pc_average[0]
-    pcx_min, pcx_max = get_detector_value_in_range(pcx, 0, 1)
+    pcx_min, pcx_max = get_detector_value_range(pcx, 0, 1)
+
     style = get_slider_style()
     widget = ipywidgets.FloatSlider(
         value=pcx,
@@ -1126,7 +1138,8 @@ def get_pcy_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
     import ipywidgets
 
     pcy = detector.pc_average[1]
-    pcy_min, pcy_max = get_detector_value_in_range(pcy, 0, 1)
+    pcy_min, pcy_max = get_detector_value_range(pcy, -0.5, 1.5)
+
     style = get_slider_style()
     widget = ipywidgets.FloatSlider(
         value=pcy,
@@ -1147,7 +1160,8 @@ def get_pcz_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
     import ipywidgets
 
     pcz = detector.pc_average[2]
-    pcz_min, pcz_max = get_detector_value_in_range(pcz, 0, 1)
+    pcz_min, pcz_max = get_detector_value_range(pcz, 0.2, 1)
+
     style = get_slider_style()
     widget = ipywidgets.FloatSlider(
         value=pcz,

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -513,7 +513,7 @@ def plot_ebsd_detector_geometry_side_view_interactive(
     annotate: bool = False,
     dimensionless: bool = True,
     **kwargs,
-) -> "widgets.VBox":
+) -> "tuple[mfigure.Figure | mfigure.SubFigure, widgets.VBox]":
     """Plot an interactive EBSD detector geometry side view.
 
     The plot allows interactive modification of the detector and sample
@@ -542,6 +542,8 @@ def plot_ebsd_detector_geometry_side_view_interactive(
 
     Returns
     -------
+    fig
+        Matplotlib figure.
     widgets
         The widget containing the sliders. Required to display the
         interactive controls.
@@ -634,4 +636,4 @@ def plot_ebsd_detector_geometry_side_view_interactive(
 
     widget = widgets.VBox([s_st, s_dt, s_px, s_py, s_pz])
 
-    return widget
+    return fig, widget

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -17,7 +17,11 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""Plotting an EBSD detector and projection centers."""
+"""Plotting an EBSD detector and projection centers.
+
+The interactive widgets require an optional dependency
+:mod:`ipywidgets`. It must only be imported if we know it's installed.
+"""
 
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -36,7 +40,7 @@ if TYPE_CHECKING:
     if dependency_version["ipywidgets"] is not None:
         import ipywidgets
 
-# Repeated in detector module
+# Repeated in detector module: keep in sync!
 DETECTOR_PLOT_FORMATS = Literal["detector", "gnomonic"]
 PROJECTION_CENTER_PLOT_MODES = Literal["map", "scatter", "3d"]
 
@@ -58,7 +62,7 @@ def plot_ebsd_detector(
     gnomonic_circles_kwargs: dict,
     gnomonic_angles: np.ndarray | list | None,
     ax: maxes.Axes | None = None,
-) -> mfigure.Figure:
+) -> mfigure.Figure | mfigure.SubFigure:
     sy, sx = detector.shape
     pcx, pcy = detector.pc_average[:2]
     bounds = detector.bounds
@@ -75,9 +79,9 @@ def plot_ebsd_detector(
         x_label = "x gnomonic"
         y_label = "y gnomonic"
 
-    fig, ax = set_up_figure_axis(ax=ax)
-    ax.axis(zoom * bounds)
-    ax.set(xlabel=x_label, ylabel=y_label, aspect="equal")
+    fig, axis = set_up_figure_axis(ax=ax)
+    axis.axis(zoom * bounds)
+    axis.set(xlabel=x_label, ylabel=y_label, aspect="equal")
 
     # Plot a pattern on the detector
     if isinstance(pattern, np.ndarray):
@@ -87,12 +91,12 @@ def plot_ebsd_detector(
                 f"{(sy, sx)}"
             )
         pattern_kwargs.setdefault("cmap", "gray")
-        ax.imshow(pattern, extent=bounds, **pattern_kwargs)
+        axis.imshow(pattern, extent=bounds, **pattern_kwargs)
     else:
         origin = (bounds[0], bounds[2])
         width = np.diff(bounds[:2])[0]
         height = np.diff(bounds[2:])[0]
-        ax.add_artist(
+        axis.add_artist(
             mpatches.Rectangle(origin, width, height, fc=DETECTOR_COLOR, zorder=-1)
         )
 
@@ -105,7 +109,7 @@ def plot_ebsd_detector(
         }
         for k, v in default_params_pc.items():
             pc_kwargs.setdefault(k, v)
-        ax.scatter(x=pcx, y=pcy, **pc_kwargs)
+        axis.scatter(x=pcx, y=pcy, **pc_kwargs)
 
     # Draw gnomonic circles centered on the projection center
     if draw_gnomonic_circles:
@@ -122,7 +126,7 @@ def plot_ebsd_detector(
         if gnomonic_angles is None:
             gnomonic_angles = np.arange(1, 9) * 10
         for angle in gnomonic_angles:
-            ax.add_patch(
+            axis.add_patch(
                 mpatches.Circle(
                     (pcx, pcy), np.tan(np.deg2rad(angle)), **gnomonic_circles_kwargs
                 )
@@ -187,12 +191,14 @@ def plot_projection_center_fit(
     kwargs.setdefault("figsize", (w, h))
 
     fig = plt.figure(**kwargs)
+
     # PCx v PCy
     ax0 = fig.add_subplot(221)
     ax0.set(xlabel="PCx", ylabel="PCy", aspect="equal")
     ax0.scatter(pcx_fit, pcy_fit, **fit_kw)
     ax0.scatter(pcx, pcy, **data_kw)
     ax0.invert_xaxis()
+
     # PCx v PCz
     ax1 = fig.add_subplot(222)
     ax1.set(xlabel="PCx", ylabel="PCz", aspect="equal")
@@ -200,6 +206,7 @@ def plot_projection_center_fit(
     ax1.scatter(pcx_fit, pcz_fit, **fit_kw)
     ax1.invert_xaxis()
     ax1.invert_yaxis()
+
     # PCz v PCy
     ax2 = fig.add_subplot(223)
     ax2.set(xlabel="PCz", ylabel="PCy", aspect="equal")
@@ -207,6 +214,7 @@ def plot_projection_center_fit(
     ax2.scatter(pcz_fit, pcy_fit, label="Fit", **fit_kw)
     ax2.plot(pcz_fit, pcy_fit_line, "r-", label="Linear fit")
     ax2.legend(bbox_to_anchor=(1.05, 1), loc="upper left", borderaxespad=0.0)
+
     # Plot PC values in 3D
     ax3: Axes3D = fig.add_subplot(224, projection="3d")
     ax3.scatter(pcx, pcz, pcy, **data_kw)
@@ -257,11 +265,11 @@ def plot_all_projection_centers(
 
     fig = plt.figure(**figure_kwargs)
     if mode == "map":
-        fig = plot_all_projection_centers_in_map(
+        plot_all_projection_centers_in_map(
             pc=pc, labels=labels, fig=fig, subplots_kw=subplots_kw, **kwargs
         )
     elif mode == "scatter":
-        fig = plot_all_projection_centers_as_scatter(
+        plot_all_projection_centers_as_scatter(
             pc=pc,
             labels=labels,
             fig=fig,
@@ -270,7 +278,7 @@ def plot_all_projection_centers(
             **kwargs,
         )
     else:
-        fig = plot_all_projection_centers_in_3d(
+        plot_all_projection_centers_in_3d(
             pc=pc, labels=labels, fig=fig, annotate=annotate, **kwargs
         )
 
@@ -283,7 +291,7 @@ def plot_all_projection_centers_in_map(
     fig: mfigure.Figure,
     subplots_kw: dict[str, Any],
     **kwargs,
-) -> mfigure.Figure:
+) -> None:
     axes = fig.subplots(**subplots_kw)
     for i, ax in enumerate(axes):
         ax.set(xlabel="Column", ylabel="Row", aspect="equal")
@@ -291,7 +299,6 @@ def plot_all_projection_centers_in_map(
         divider = make_axes_locatable(ax)
         cax = divider.append_axes(position="right", size="5%", pad=0.1)
         fig.colorbar(im, cax=cax, label=labels[i])
-    return fig
 
 
 def plot_all_projection_centers_as_scatter(
@@ -301,7 +308,7 @@ def plot_all_projection_centers_as_scatter(
     subplots_kw: dict,
     annotate: bool,
     **kwargs,
-) -> mfigure.Figure:
+) -> None:
     pc_flattened = pc.reshape(-1, 3)
     axes = fig.subplots(**subplots_kw)
     for i, (j, k) in enumerate([[0, 1], [0, 2], [2, 1]]):
@@ -315,7 +322,6 @@ def plot_all_projection_centers_as_scatter(
     axes[0].invert_xaxis()
     axes[1].invert_xaxis()
     axes[1].invert_yaxis()
-    return fig
 
 
 def plot_all_projection_centers_in_3d(
@@ -324,7 +330,7 @@ def plot_all_projection_centers_in_3d(
     fig: mfigure.Figure,
     annotate: bool,
     **kwargs,
-) -> mfigure.Figure:
+) -> None:
     nav_shape = pc.shape[: pc.ndim - 1]
     nav_dim = len(nav_shape)
     pcx, pcy, pcz = pc.reshape(-1, 3).T
@@ -348,10 +354,8 @@ def plot_all_projection_centers_in_3d(
         for i, (x, z, y) in enumerate(zip(pcx, pcz, pcy)):
             ax.text(x, z, y, i)
 
-    return fig
 
-
-def plot_ebsd_detector_geometry_side_view(
+def plot_detector_sample_geometry_side_view(
     detector: EBSDDetector,
     ax: maxes.Axes | None = None,
     annotate: bool = False,
@@ -511,7 +515,7 @@ def plot_ebsd_detector_geometry_side_view(
     return fig
 
 
-def update_side_view(
+def update_detector_sample_geometry_side_view(
     detector: EBSDDetector,
     ax: maxes.Axes,
     annotate: bool = False,
@@ -519,12 +523,12 @@ def update_side_view(
 ) -> None:
     """Clear *ax* and redraw the side view for *detector*."""
     ax.clear()
-    plot_ebsd_detector_geometry_side_view(
+    plot_detector_sample_geometry_side_view(
         detector, ax=ax, annotate=annotate, dimensionless=dimensionless
     )
 
 
-def plot_ebsd_detector_geometry_top_view(
+def plot_detector_sample_geometry_top_view(
     detector: EBSDDetector,
     ax: maxes.Axes | None = None,
     annotate: bool = False,
@@ -550,17 +554,13 @@ def plot_ebsd_detector_geometry_top_view(
     L = detector.specimen_scintillator_distance[0]
     sample_length = L * 1.5
     azimuthal = np.deg2rad(detector.azimuthal)
-    theta = np.deg2rad(detector.tilt)
 
     beam = np.zeros(2)
-
-    # Sample-detector distance (shortened by the detector tilt)
-    d = L * np.cos(theta)
 
     # PC in microscope X-Y coordinates, with the screen normal pointing
     # towards the interaction volume
     det_normal = np.array([np.sin(azimuthal), np.cos(azimuthal)])
-    pc_pos = d * det_normal
+    pc_pos = L * det_normal
 
     # Unit vector along the detector width, perpendicular to the normal
     width_dir = np.array([-np.cos(azimuthal), np.sin(azimuthal)])
@@ -674,7 +674,7 @@ def plot_ebsd_detector_geometry_top_view(
     return fig
 
 
-def update_top_view(
+def update_detector_sample_geometry_top_view(
     detector: EBSDDetector,
     ax: maxes.Axes,
     annotate: bool = False,
@@ -682,7 +682,7 @@ def update_top_view(
 ) -> None:
     """Clear *ax* and redraw the top view for *detector*."""
     ax.clear()
-    plot_ebsd_detector_geometry_top_view(
+    plot_detector_sample_geometry_top_view(
         detector, ax=ax, annotate=annotate, dimensionless=dimensionless
     )
 
@@ -710,94 +710,65 @@ def update_detector_plane(
     )
 
 
-def plot_ebsd_detector_geometry_side_view_interactive(
+def plot_detector_sample_geometry_side_view_interactive(
     detector: EBSDDetector,
-    inplace: bool = False,
     ax: maxes.Axes | None = None,
     annotate: bool = False,
     dimensionless: bool = True,
     **kwargs,
-) -> "tuple[mfigure.Figure | mfigure.SubFigure, ipywidgets.VBox]":
-    """Plot an interactive EBSD detector geometry side view.
-
-    The plot allows interactive modification of the detector and sample
-    tilts and the projection center (PC) values.
-
-    Parameters
-    ----------
-    detector
-        EBSD detector.
-    inplace
-        Whether to edit the given *detector* inplace. The given detector
-        is not affected by default.
-    ax
-        The Matplotlib axis to plot in. If not given, a new figure
-        and axis are created.
-    annotate
-        Whether to annotate the various components of the geometry.
-        Default is False.
-    dimensionless
-        Whether to ignore the
-        :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
-        drawing the plot axes. Default is True.
-    **kwargs
-        Keyword arguments passed to
-        :func:`~matplotlib.pyplot.figure` if *ax* is not given.
-
-    Returns
-    -------
-    fig
-        Matplotlib figure.
-    controls
-        The widget controls. Required to display the interactive
-        controls.
-
-    Notes
-    -----
-    Requires that :mod:`ipywidgets` is installed. If :mod:`psygnal` is
-    installed, the plot is driven by signals emitted from the detector
-    property setters.
+) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]":
+    """See the docstring of
+    :meth:`~kikuchipy.detectors.EBSDDetector.plot_side_view` for
+    details.
     """
     verify_dependency_or_raise("ipywidgets", "Interactive detector plots")
     verify_dependency_or_raise("IPython", "Interactive detector plots")
 
     import ipywidgets
 
-    if inplace:
-        det = detector
-    else:
-        det = detector.deepcopy()
-    pcx, pcy, pcz = det.pc_average
-    det.pc = [pcx, pcy, pcz]
+    detector.pc = detector.pc_average
+    sample_tilt_slider = get_sample_tilt_slider(detector)
+    detector_tilt_slider = get_detector_tilt_slider(detector)
+    azimuthal_slider = get_detector_azimuthal_slider(detector)
+    pcy_slider = get_pcy_slider(detector)
+    pcz_slider = get_pcz_slider(detector)
+    sliders = [
+        sample_tilt_slider,
+        detector_tilt_slider,
+        azimuthal_slider,
+        pcy_slider,
+        pcz_slider,
+    ]
 
     fig, ax = set_up_figure_axis(ax=ax, **kwargs)
     ax.set_title("Side view")
 
-    sliders = make_detector_sliders(det)
-
     def redraw(*args: Any) -> None:
-        update_side_view(det, ax, annotate=annotate, dimensionless=dimensionless)
+        update_detector_sample_geometry_side_view(
+            detector, ax, annotate=annotate, dimensionless=dimensionless
+        )
         fig.canvas.draw_idle()
 
     def update_detector_from_sliders():
-        det.sample_tilt = sliders["sample_tilt"].value
-        det.tilt = sliders["tilt"].value
-        det.azimuthal = sliders["azimuthal"].value
-        det.pc = [sliders["pcx"].value, sliders["pcy"].value, sliders["pcz"].value]
+        detector.sample_tilt = sample_tilt_slider.value
+        detector.tilt = detector_tilt_slider.value
+        detector.azimuthal = azimuthal_slider.value
+        detector.pcy = pcy_slider.value
+        detector.pcz = pcz_slider.value
 
-    if det._has_signals:
-        det._sample_tilt_changed.connect(redraw)
-        det._tilt_changed.connect(redraw)
-        det._azimuthal_changed.connect(redraw)
-        det._pc_changed.connect(redraw)
+    if detector._has_signals:
+        detector._sample_tilt_changed.connect(redraw)
+        detector._tilt_changed.connect(redraw)
+        detector._azimuthal_changed.connect(redraw)
+        detector._pc_changed.connect(redraw)
 
         def on_slider_change(change: Any = None) -> None:
             # Block to redraw only once
             with (
-                det._sample_tilt_changed.blocked(),
-                det._tilt_changed.blocked(),
-                det._azimuthal_changed.blocked(),
-                det._pc_changed.blocked(),
+                detector._sample_tilt_changed.blocked(),
+                detector._tilt_changed.blocked(),
+                detector._azimuthal_changed.blocked(),
+                detector._pc_changed.blocked(),
             ):
                 update_detector_from_sliders()
     else:
@@ -806,17 +777,94 @@ def plot_ebsd_detector_geometry_side_view_interactive(
             update_detector_from_sliders()
             redraw()
 
-    for s in sliders.values():
-        s.observe(on_slider_change, names="value")
+    for slider in sliders:
+        slider.observe(on_slider_change, names="value")
 
     redraw()  # Initial draw
 
-    controls = ipywidgets.VBox(list(sliders.values()))
+    controls = ipywidgets.VBox(sliders)
 
-    return fig, controls
+    return controls, fig
 
 
-def plot_ebsd_detector_combined_interactive(
+def plot_detector_sample_geometry_top_view_interactive(
+    detector: EBSDDetector,
+    ax: maxes.Axes | None = None,
+    annotate: bool = False,
+    dimensionless: bool = True,
+    **kwargs,
+) -> "tuple[ipywidgets.VBox, mfigure.Figure | mfigure.SubFigure]":
+    """See the docstring of
+    :meth:`~kikuchipy.detectors.EBSDDetector.plot_top_view` for
+    details.
+    """
+    verify_dependency_or_raise("ipywidgets", "Interactive detector plots")
+    verify_dependency_or_raise("IPython", "Interactive detector plots")
+
+    import ipywidgets
+
+    detector.pc = detector.pc_average
+    sample_tilt_slider = get_sample_tilt_slider(detector)
+    detector_tilt_slider = get_detector_tilt_slider(detector)
+    azimuthal_slider = get_detector_azimuthal_slider(detector)
+    pcx_slider = get_pcx_slider(detector)
+    pcz_slider = get_pcz_slider(detector)
+    sliders = [
+        sample_tilt_slider,
+        detector_tilt_slider,
+        azimuthal_slider,
+        pcx_slider,
+        pcz_slider,
+    ]
+
+    fig, ax = set_up_figure_axis(ax=ax, **kwargs)
+    ax.set_title("Top view")
+
+    def redraw(*args: Any) -> None:
+        update_detector_sample_geometry_side_view(
+            detector, ax, annotate=annotate, dimensionless=dimensionless
+        )
+        fig.canvas.draw_idle()
+
+    def update_detector_from_sliders():
+        detector.sample_tilt = sample_tilt_slider.value
+        detector.tilt = detector_tilt_slider.value
+        detector.azimuthal = azimuthal_slider.value
+        detector.pcx = pcx_slider.value
+        detector.pcz = pcz_slider.value
+
+    if detector._has_signals:
+        detector._sample_tilt_changed.connect(redraw)
+        detector._tilt_changed.connect(redraw)
+        detector._azimuthal_changed.connect(redraw)
+        detector._pc_changed.connect(redraw)
+
+        def on_slider_change(change: Any = None) -> None:
+            # Block to redraw only once
+            with (
+                detector._sample_tilt_changed.blocked(),
+                detector._tilt_changed.blocked(),
+                detector._azimuthal_changed.blocked(),
+                detector._pc_changed.blocked(),
+            ):
+                update_detector_from_sliders()
+    else:
+
+        def on_slider_change(change: Any = None) -> None:
+            update_detector_from_sliders()
+            redraw()
+
+    for slider in sliders:
+        slider.observe(on_slider_change, names="value")
+
+    redraw()  # Initial draw
+
+    controls = ipywidgets.VBox(sliders)
+
+    return controls, fig
+
+
+def plot_detector_sample_geometry_interactive(
     detector: EBSDDetector,
     inplace: bool = False,
     annotate: bool = False,
@@ -872,8 +920,22 @@ def plot_ebsd_detector_combined_interactive(
         det = detector
     else:
         det = detector.deepcopy()
-    pcx, pcy, pcz = det.pc_average
-    det.pc = [pcx, pcy, pcz]
+    det.pc = det.pc_average
+
+    sample_tilt_slider = get_sample_tilt_slider(detector)
+    detector_tilt_slider = get_detector_tilt_slider(detector)
+    azimuthal_slider = get_detector_azimuthal_slider(detector)
+    pcx_slider = get_pcx_slider(detector)
+    pcy_slider = get_pcy_slider(detector)
+    pcz_slider = get_pcz_slider(detector)
+    sliders = [
+        sample_tilt_slider,
+        detector_tilt_slider,
+        azimuthal_slider,
+        pcx_slider,
+        pcy_slider,
+        pcz_slider,
+    ]
 
     w, h = plt.rcParams["figure.figsize"]
     kwargs.setdefault("layout", "constrained")
@@ -881,14 +943,16 @@ def plot_ebsd_detector_combined_interactive(
     fig = plt.figure(**kwargs)
     ax_side, ax_top, ax_det = fig.subplots(1, 3)
 
-    sliders = make_detector_sliders(det)
-
     def redraw_side(*args: Any) -> None:
-        update_side_view(det, ax_side, annotate=annotate, dimensionless=dimensionless)
+        update_detector_sample_geometry_side_view(
+            det, ax_side, annotate=annotate, dimensionless=dimensionless
+        )
         ax_side.set_title("Side view")
 
     def redraw_top(*args: Any) -> None:
-        update_top_view(det, ax_top, annotate=annotate, dimensionless=dimensionless)
+        update_detector_sample_geometry_top_view(
+            det, ax_top, annotate=annotate, dimensionless=dimensionless
+        )
         ax_top.set_title("Top view")
 
     def redraw_det(*args: Any) -> None:
@@ -902,24 +966,24 @@ def plot_ebsd_detector_combined_interactive(
         fig.canvas.draw_idle()
 
     def update_detector_from_sliders():
-        det.sample_tilt = sliders["sample_tilt"].value
-        det.tilt = sliders["tilt"].value
-        det.azimuthal = sliders["azimuthal"].value
-        det.pc = [sliders["pcx"].value, sliders["pcy"].value, sliders["pcz"].value]
+        det.sample_tilt = sample_tilt_slider.value
+        det.tilt = detector_tilt_slider.value
+        det.azimuthal = azimuthal_slider.value
+        det.pc = [pcx_slider.value, pcy_slider.value, pcz_slider.value]
 
     if det._has_signals:
         det._sample_tilt_changed.connect(redraw_side)
         det._sample_tilt_changed.connect(redraw_top)
-        det._sample_tilt_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._sample_tilt_changed.connect(lambda *_: fig.canvas.draw_idle())
         det._tilt_changed.connect(redraw_side)
         det._tilt_changed.connect(redraw_top)
-        det._tilt_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._tilt_changed.connect(lambda *_: fig.canvas.draw_idle())
         det._azimuthal_changed.connect(redraw_top)
-        det._azimuthal_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._azimuthal_changed.connect(lambda *_: fig.canvas.draw_idle())
         det._pc_changed.connect(redraw_side)
         det._pc_changed.connect(redraw_top)
         det._pc_changed.connect(redraw_det)
-        det._pc_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._pc_changed.connect(lambda *_: fig.canvas.draw_idle())
 
         def on_slider_change(change: Any = None) -> None:
             with (
@@ -936,12 +1000,12 @@ def plot_ebsd_detector_combined_interactive(
             update_detector_from_sliders()
             redraw_all()
 
-    for s in sliders.values():
-        s.observe(on_slider_change, names="value")
+    for slider in sliders:
+        slider.observe(on_slider_change, names="value")
 
     redraw_all()  # Initial draw
 
-    controls = ipywidgets.VBox(list(sliders.values()))
+    controls = ipywidgets.VBox(sliders)
 
     return fig, controls
 
@@ -960,82 +1024,136 @@ def set_up_figure_axis(
     return fig, ax
 
 
-def make_detector_sliders(
-    detector: EBSDDetector,
-) -> dict[str, "ipywidgets.FloatSlider"]:
-    """Return a dictionary of sliders for the *detector*.
+def get_detector_value_in_range(
+    value: float, vmin: float, vmax: float
+) -> tuple[float, float]:
+    margin = max((vmax - vmin) * 0.1, 0.1)
+    if value < vmin:
+        vmin = value - margin
+    if value > vmax:
+        vmax = value + margin
+    return vmin, vmax
 
-    Requires :mod:`ipywidgets`.
-    """
+
+def get_slider_style() -> dict[str, str]:
+    return {"description_width": "initial"}
+
+
+def get_sample_tilt_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
+    """Return an :mod:`ipywidgets` slider from a *detector*."""
     verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
 
     import ipywidgets
 
-    def get_range(val, default_range):
-        vmin, vmax = default_range
-        margin = max((vmax - vmin) * 0.1, 0.1)
-        if val < vmin:
-            vmin = val - margin
-        if val > vmax:
-            vmax = val + margin
-        return vmin, vmax
+    style = get_slider_style()
+    widget = ipywidgets.FloatSlider(
+        value=detector.sample_tilt,
+        min=0,
+        max=180,
+        step=0.1,
+        description="Sample tilt",
+        style=style,
+    )
 
-    pcx, pcy, pcz = detector.pc_average
-    px_min, px_max = get_range(pcx, (0, 1))
-    py_min, py_max = get_range(pcy, (0, 1))
-    pz_min, pz_max = get_range(pcz, (0, 1))
+    return widget
 
-    style = {"description_width": "initial"}
 
-    sliders = {
-        "sample_tilt": ipywidgets.FloatSlider(
-            value=detector.sample_tilt,
-            min=0,
-            max=180,
-            step=0.1,
-            description="Sample tilt",
-            style=style,
-        ),
-        "tilt": ipywidgets.FloatSlider(
-            value=detector.tilt,
-            min=0,
-            max=180,
-            step=0.1,
-            description="Detector tilt",
-            style=style,
-        ),
-        "pcx": ipywidgets.FloatSlider(
-            value=pcx,
-            min=px_min,
-            max=px_max,
-            step=0.01,
-            description="PCx",
-            style=style,
-        ),
-        "pcy": ipywidgets.FloatSlider(
-            value=pcy,
-            min=py_min,
-            max=py_max,
-            step=0.01,
-            description="PCy",
-            style=style,
-        ),
-        "pcz": ipywidgets.FloatSlider(
-            value=pcz,
-            min=pz_min,
-            max=pz_max,
-            step=0.01,
-            description="PCz",
-            style=style,
-        ),
-        "azimuthal": ipywidgets.FloatSlider(
-            value=detector.azimuthal,
-            min=-180,
-            max=180,
-            step=0.1,
-            description="Azimuthal",
-            style=style,
-        ),
-    }
+def get_detector_tilt_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
+    """Return an :mod:`ipywidgets` slider from a *detector*."""
+    verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
 
-    return sliders
+    import ipywidgets
+
+    style = get_slider_style()
+    widget = ipywidgets.FloatSlider(
+        value=detector.tilt,
+        min=0,
+        max=180,
+        step=0.1,
+        description="Detector tilt",
+        style=style,
+    )
+
+    return widget
+
+
+def get_detector_azimuthal_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
+    """Return an :mod:`ipywidgets` slider from a *detector*."""
+    verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
+
+    import ipywidgets
+
+    style = get_slider_style()
+    widget = ipywidgets.FloatSlider(
+        value=detector.azimuthal,
+        min=-180,
+        max=180,
+        step=0.1,
+        description="Azimuthal",
+        style=style,
+    )
+
+    return widget
+
+
+def get_pcx_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
+    """Return an :mod:`ipywidgets` slider from a *detector*."""
+    verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
+
+    import ipywidgets
+
+    pcx = detector.pc_average[0]
+    pcx_min, pcx_max = get_detector_value_in_range(pcx, 0, 1)
+    style = get_slider_style()
+    widget = ipywidgets.FloatSlider(
+        value=pcx,
+        min=pcx_min,
+        max=pcx_max,
+        step=0.01,
+        description="PCx",
+        style=style,
+    )
+
+    return widget
+
+
+def get_pcy_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
+    """Return an :mod:`ipywidgets` slider from a *detector*."""
+    verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
+
+    import ipywidgets
+
+    pcy = detector.pc_average[1]
+    pcy_min, pcy_max = get_detector_value_in_range(pcy, 0, 1)
+    style = get_slider_style()
+    widget = ipywidgets.FloatSlider(
+        value=pcy,
+        min=pcy_min,
+        max=pcy_max,
+        step=0.01,
+        description="PCy",
+        style=style,
+    )
+
+    return widget
+
+
+def get_pcz_slider(detector: EBSDDetector) -> "ipywidgets.FloatSlider":
+    """Return an :mod:`ipywidgets` slider from a *detector*."""
+    verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
+
+    import ipywidgets
+
+    pcz = detector.pc_average[2]
+    pcz_min, pcz_max = get_detector_value_in_range(pcz, 0, 1)
+    style = get_slider_style()
+    widget = ipywidgets.FloatSlider(
+        value=pcz,
+        min=pcz_min,
+        max=pcz_max,
+        step=0.01,
+        description="PCz",
+        style=style,
+    )
+
+    return widget

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -25,6 +25,7 @@ The interactive widgets require an optional dependency
 
 from typing import TYPE_CHECKING, Any, Literal
 
+from matplotlib import ticker
 import matplotlib.axes as maxes
 import matplotlib.figure as mfigure
 import matplotlib.lines as mlines
@@ -68,6 +69,8 @@ def plot_ebsd_detector(
     pcx, pcy = detector.pc_average[:2]
     bounds = detector.bounds
 
+    fig, axis = set_up_figure_axis(ax=ax)
+
     if coords_fmt == "detector":
         pcy *= sy - 1
         pcx *= sx - 1
@@ -79,8 +82,10 @@ def plot_ebsd_detector(
         bounds = detector._average_gnomonic_bounds
         x_label = "Gnomonic X"
         y_label = "Gnomonic Y"
+        formatter = ticker.StrMethodFormatter("{x:.2f}")
+        axis.xaxis.set_major_formatter(formatter)
+        axis.yaxis.set_major_formatter(formatter)
 
-    fig, axis = set_up_figure_axis(ax=ax)
     axis.axis(zoom * bounds)
     axis.set(xlabel=x_label, ylabel=y_label, aspect="equal")
 
@@ -640,8 +645,8 @@ def update_detector_sample_geometry_top_view(
 def update_detector_plane(
     detector: EBSDDetector,
     ax: maxes.Axes,
-    coords_fmt: DETECTOR_PLOT_FORMATS = "detector",
-    zoom: float = 1.0,
+    coords_fmt: DETECTOR_PLOT_FORMATS,
+    zoom: float,
 ) -> None:
     """Clear *ax* and redraw the detector plane for *detector*."""
     ax.clear()
@@ -650,7 +655,7 @@ def update_detector_plane(
         coords_fmt=coords_fmt,
         zoom=zoom,
         show_pc=True,
-        draw_gnomonic_circles=False,
+        draw_gnomonic_circles=coords_fmt == "gnomonic",
         pattern=None,
         pattern_kwargs={},
         pc_kwargs={},
@@ -804,7 +809,7 @@ def plot_detector_sample_geometry_interactive(
     inplace: bool = False,
     legend: bool = False,
     dimensionless: bool = True,
-    coords_fmt: DETECTOR_PLOT_FORMATS = "detector",
+    coords_fmt: DETECTOR_PLOT_FORMATS = "gnomonic",
     zoom: float = 1.0,
     **kwargs,
 ) -> "tuple[mfigure.Figure, ipywidgets.VBox]":
@@ -826,8 +831,8 @@ def plot_detector_sample_geometry_interactive(
         :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
         drawing the side-view plot axes. Default is True.
     coords_fmt
-        Detector plane coordinate format: ``"detector"`` (default) or
-        ``"gnomonic"``.
+        Detector plane coordinate format: "gnomonic" (default) or
+        "detector".
     zoom
         Zoom factor for the detector plane. Default is 1.0.
     **kwargs

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -509,8 +509,8 @@ def plot_detector_sample_geometry_side_view(
         unit = ""
     else:
         unit = " [mm]"
-    ax.set_xlabel(f"y microscope{unit}")
-    ax.set_ylabel(f"z microscope{unit}")
+    ax.set_xlabel(f"Microscope Y{unit}")
+    ax.set_ylabel(f"Microscope Z{unit}")
 
     return fig
 

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -771,6 +771,7 @@ def plot_detector_sample_geometry_side_view_interactive(
                 detector._pc_changed.blocked(),
             ):
                 update_detector_from_sliders()
+            redraw()
     else:
 
         def on_slider_change(change: Any = None) -> None:
@@ -848,6 +849,7 @@ def plot_detector_sample_geometry_top_view_interactive(
                 detector._pc_changed.blocked(),
             ):
                 update_detector_from_sliders()
+            redraw()
     else:
 
         def on_slider_change(change: Any = None) -> None:

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -473,6 +473,7 @@ def plot_detector_sample_geometry_side_view(
         ax.legend(
             handles=[beam_handle, *ax.get_legend_handles_labels()[0]],
             loc="best",
+            borderpad=max([plt.rcParams["legend.borderpad"], 0.6]),
         )
 
     if dimensionless:

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -30,13 +30,14 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 
-from kikuchipy._constants import dependency_version
+from kikuchipy._constants import dependency_version, verify_dependency_or_raise
 from kikuchipy.detectors._ebsd_detector import EBSDDetector
 
 if TYPE_CHECKING:
     if dependency_version["ipywidgets"] is not None:
-        import ipywidgets as widgets
+        import ipywidgets
 
+# Repeated in detector module
 DETECTOR_PLOT_FORMATS = Literal["detector", "gnomonic"]
 PROJECTION_CENTER_PLOT_MODES = Literal["map", "scatter", "3d"]
 
@@ -52,6 +53,7 @@ def plot_ebsd_detector(
     pc_kwargs: dict,
     gnomonic_circles_kwargs: dict,
     gnomonic_angles: np.ndarray | list | None,
+    ax: maxes.Axes | None = None,
 ) -> mfigure.Figure:
     sy, sx = detector.shape
     pcx, pcy = detector.pc_average[:2]
@@ -69,7 +71,7 @@ def plot_ebsd_detector(
         x_label = "x gnomonic"
         y_label = "y gnomonic"
 
-    fig, ax = plt.subplots()
+    fig, ax = set_up_figure_axis(ax=ax)
     ax.axis(zoom * bounds)
     ax.set(xlabel=x_label, ylabel=y_label, aspect="equal")
 
@@ -357,14 +359,7 @@ def plot_ebsd_detector_geometry_side_view(
     """See the docstring of the EBSD detector method using this
     function.
     """
-    if ax is None:
-        w, h = plt.rcParams["figure.figsize"]
-        kwargs.setdefault("layout", "constrained")
-        kwargs.setdefault("figsize", (w, h))
-        fig = plt.figure(**kwargs)
-        ax = fig.add_subplot()
-    else:
-        fig = ax.figure
+    fig, ax = set_up_figure_axis(ax=ax, **kwargs)
 
     # Dimensions in microns
     height = detector.height
@@ -506,6 +501,42 @@ def plot_ebsd_detector_geometry_side_view(
     return fig
 
 
+def update_side_view(
+    detector: EBSDDetector,
+    ax: maxes.Axes,
+    annotate: bool = False,
+    dimensionless: bool = True,
+) -> None:
+    """Clear *ax* and redraw the side view for *detector*."""
+    ax.clear()
+    plot_ebsd_detector_geometry_side_view(
+        detector, ax=ax, annotate=annotate, dimensionless=dimensionless
+    )
+
+
+def update_detector_plane(
+    detector: EBSDDetector,
+    ax: maxes.Axes,
+    coords_fmt: DETECTOR_PLOT_FORMATS = "detector",
+    zoom: float = 1.0,
+) -> None:
+    """Clear *ax* and redraw the detector plane for *detector*."""
+    ax.clear()
+    plot_ebsd_detector(
+        detector,
+        coords_fmt=coords_fmt,
+        zoom=zoom,
+        show_pc=True,
+        draw_gnomonic_circles=False,
+        pattern=None,
+        pattern_kwargs={},
+        pc_kwargs={},
+        gnomonic_circles_kwargs={},
+        gnomonic_angles=None,
+        ax=ax,
+    )
+
+
 def plot_ebsd_detector_geometry_side_view_interactive(
     detector: EBSDDetector,
     inplace: bool = False,
@@ -513,7 +544,7 @@ def plot_ebsd_detector_geometry_side_view_interactive(
     annotate: bool = False,
     dimensionless: bool = True,
     **kwargs,
-) -> "tuple[mfigure.Figure | mfigure.SubFigure, widgets.VBox]":
+) -> "tuple[mfigure.Figure | mfigure.SubFigure, ipywidgets.VBox]":
     """Plot an interactive EBSD detector geometry side view.
 
     The plot allows interactive modification of the detector and sample
@@ -544,20 +575,20 @@ def plot_ebsd_detector_geometry_side_view_interactive(
     -------
     fig
         Matplotlib figure.
-    widgets
-        The widget containing the sliders. Required to display the
-        interactive controls.
+    controls
+        The widget controls. Required to display the interactive
+        controls.
 
     Notes
     -----
-    Requires that :mod:`ipywidgets` is installed.
+    Requires that :mod:`ipywidgets` is installed. If :mod:`psygnal` is
+    installed, the plot is driven by signals emitted from the detector
+    property setters.
     """
-    if dependency_version["ipywidgets"] is None:
-        raise ImportError("Requires that ipywidgets is installed")
-    if dependency_version["IPython"] is None:
-        raise ImportError("Requires that IPython is installed")
+    verify_dependency_or_raise("ipywidgets", "Interactive detector plots")
+    verify_dependency_or_raise("IPython", "Interactive detector plots")
 
-    import ipywidgets as widgets
+    import ipywidgets
 
     if inplace:
         det = detector
@@ -566,6 +597,182 @@ def plot_ebsd_detector_geometry_side_view_interactive(
     pcx, pcy, pcz = det.pc_average
     det.pc = [pcx, pcy, pcz]
 
+    fig, ax = set_up_figure_axis(ax=ax, **kwargs)
+
+    sliders = make_detector_sliders(det)
+
+    def redraw(*args: Any) -> None:
+        update_side_view(det, ax, annotate=annotate, dimensionless=dimensionless)
+        fig.canvas.draw_idle()
+
+    if det._has_signals:
+        det._sample_tilt_changed.connect(redraw)
+        det._tilt_changed.connect(redraw)
+        det._pc_changed.connect(redraw)
+
+        def on_slider_change(change: Any = None) -> None:
+            # Block signals while setting all values to avoid multiple
+            # redraws, then emit manually once
+            with (
+                det._sample_tilt_changed.blocked(),
+                det._tilt_changed.blocked(),
+                det._pc_changed.blocked(),
+            ):
+                det.sample_tilt = sliders["sample_tilt"].value
+                det.tilt = sliders["tilt"].value
+                det.pc = [
+                    sliders["pcx"].value,
+                    sliders["pcy"].value,
+                    sliders["pcz"].value,
+                ]
+    else:
+
+        def on_slider_change(change: Any = None) -> None:
+            det.sample_tilt = sliders["sample_tilt"].value
+            det.tilt = sliders["tilt"].value
+            det.pc = [
+                sliders["pcx"].value,
+                sliders["pcy"].value,
+                sliders["pcz"].value,
+            ]
+            redraw()
+
+    for s in sliders.values():
+        s.observe(on_slider_change, names="value")
+
+    redraw()  # Initial draw
+
+    controls = ipywidgets.VBox(list(sliders.values()))
+
+    return fig, controls
+
+
+def plot_ebsd_detector_combined_interactive(
+    detector: EBSDDetector,
+    inplace: bool = False,
+    annotate: bool = False,
+    dimensionless: bool = True,
+    coords_fmt: DETECTOR_PLOT_FORMATS = "detector",
+    zoom: float = 1.0,
+    **kwargs,
+) -> "tuple[mfigure.Figure, ipywidgets.VBox]":
+    """Plot the side view and detector plane side by side with
+    interactive controls.
+
+    Parameters
+    ----------
+    detector
+        EBSD detector.
+    inplace
+        Whether to edit the given *detector* inplace. The given detector
+        is not affected by default.
+    annotate
+        Whether to annotate the side-view components.
+        Default is False.
+    dimensionless
+        Whether to ignore
+        :attr:`~kikuchipy.detectors.EBSDDetector.px_size` when
+        drawing the side-view plot axes. Default is True.
+    coords_fmt
+        Detector plane coordinate format: ``"detector"`` (default) or
+        ``"gnomonic"``.
+    zoom
+        Zoom factor for the detector plane. Default is 1.0.
+    **kwargs
+        Keyword arguments passed to :func:`~matplotlib.pyplot.figure`.
+
+    Returns
+    -------
+    fig
+        Matplotlib figure.
+    controls
+        ipywidgets VBox containing slider controls.
+
+    Notes
+    -----
+    Requires that :mod:`ipywidgets` is installed. If :mod:`psygnal` is
+    installed, the plots are driven by signals emitted from the detector
+    property setters.
+    """
+    verify_dependency_or_raise("ipywidgets", "Interactive detector plots")
+    verify_dependency_or_raise("IPython", "Interactive detector plots")
+
+    import ipywidgets
+
+    if inplace:
+        det = detector
+    else:
+        det = detector.deepcopy()
+    pcx, pcy, pcz = det.pc_average
+    det.pc = [pcx, pcy, pcz]
+
+    w, h = plt.rcParams["figure.figsize"]
+    kwargs.setdefault("layout", "constrained")
+    kwargs.setdefault("figsize", (2 * w, h))
+    fig = plt.figure(**kwargs)
+    ax_side, ax_det = fig.subplots(1, 2)
+
+    sliders = make_detector_sliders(det)
+
+    def redraw_side(*args: Any) -> None:
+        update_side_view(det, ax_side, annotate=annotate, dimensionless=dimensionless)
+
+    def redraw_det(*args: Any) -> None:
+        update_detector_plane(det, ax_det, coords_fmt=coords_fmt, zoom=zoom)
+
+    def redraw_all() -> None:
+        redraw_side()
+        redraw_det()
+        fig.canvas.draw_idle()
+
+    if det._has_signals:
+        det._sample_tilt_changed.connect(redraw_side)
+        det._sample_tilt_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._tilt_changed.connect(redraw_side)
+        det._tilt_changed.connect(lambda *a: fig.canvas.draw_idle())
+        det._pc_changed.connect(redraw_side)
+        det._pc_changed.connect(redraw_det)
+        det._pc_changed.connect(lambda *a: fig.canvas.draw_idle())
+
+        def on_slider_change(change: Any = None) -> None:
+            with (
+                det._sample_tilt_changed.blocked(),
+                det._tilt_changed.blocked(),
+                det._pc_changed.blocked(),
+            ):
+                det.sample_tilt = sliders["sample_tilt"].value
+                det.tilt = sliders["tilt"].value
+                det.pc = [
+                    sliders["pcx"].value,
+                    sliders["pcy"].value,
+                    sliders["pcz"].value,
+                ]
+            redraw_all()
+    else:
+
+        def on_slider_change(change: Any = None) -> None:
+            det.sample_tilt = sliders["sample_tilt"].value
+            det.tilt = sliders["tilt"].value
+            det.pc = [
+                sliders["pcx"].value,
+                sliders["pcy"].value,
+                sliders["pcz"].value,
+            ]
+            redraw_all()
+
+    for s in sliders.values():
+        s.observe(on_slider_change, names="value")
+
+    redraw_all()  # Initial draw
+
+    controls = ipywidgets.VBox(list(sliders.values()))
+
+    return fig, controls
+
+
+def set_up_figure_axis(
+    ax: maxes.Axes | None = None, **kwargs
+) -> tuple[mfigure.Figure | mfigure.SubFigure, maxes.Axes]:
     if ax is None:
         w, h = plt.rcParams["figure.figsize"]
         kwargs.setdefault("layout", "constrained")
@@ -574,6 +781,19 @@ def plot_ebsd_detector_geometry_side_view_interactive(
         ax = fig.add_subplot()
     else:
         fig = ax.figure
+    return fig, ax
+
+
+def make_detector_sliders(
+    detector: EBSDDetector,
+) -> dict[str, "ipywidgets.FloatSlider"]:
+    """Return a dictionary of sliders for the *detector*.
+
+    Requires :mod:`ipywidgets`.
+    """
+    verify_dependency_or_raise("ipywidgets", "Interactive sliders require")
+
+    import ipywidgets
 
     def get_range(val, default_range):
         vmin, vmax = default_range
@@ -584,56 +804,54 @@ def plot_ebsd_detector_geometry_side_view_interactive(
             vmax = val + margin
         return vmin, vmax
 
+    pcx, pcy, pcz = detector.pc_average
     px_min, px_max = get_range(pcx, (0, 1))
     py_min, py_max = get_range(pcy, (0, 1))
     pz_min, pz_max = get_range(pcz, (0, 1))
 
     style = {"description_width": "initial"}
-    s_st = widgets.FloatSlider(
-        value=det.sample_tilt,
-        min=0,
-        max=180,
-        step=0.1,
-        description="Sample tilt",
-        style=style,
-    )
-    s_dt = widgets.FloatSlider(
-        value=det.tilt,
-        min=0,
-        max=180,
-        step=0.1,
-        description="Detector tilt",
-        style=style,
-    )
-    s_px = widgets.FloatSlider(
-        value=pcx, min=px_min, max=px_max, step=0.01, description="PCx", style=style
-    )
-    s_py = widgets.FloatSlider(
-        value=pcy, min=py_min, max=py_max, step=0.01, description="PCy", style=style
-    )
-    s_pz = widgets.FloatSlider(
-        value=pcz, min=pz_min, max=pz_max, step=0.01, description="PCz", style=style
-    )
 
-    def update(change: Any = None) -> None:
-        det.sample_tilt = s_st.value
-        det.tilt = s_dt.value
-        det.pc = [s_px.value, s_py.value, s_pz.value]
+    sliders = {
+        "sample_tilt": ipywidgets.FloatSlider(
+            value=detector.sample_tilt,
+            min=0,
+            max=180,
+            step=0.1,
+            description="Sample tilt",
+            style=style,
+        ),
+        "tilt": ipywidgets.FloatSlider(
+            value=detector.tilt,
+            min=0,
+            max=180,
+            step=0.1,
+            description="Detector tilt",
+            style=style,
+        ),
+        "pcx": ipywidgets.FloatSlider(
+            value=pcx,
+            min=px_min,
+            max=px_max,
+            step=0.01,
+            description="PCx",
+            style=style,
+        ),
+        "pcy": ipywidgets.FloatSlider(
+            value=pcy,
+            min=py_min,
+            max=py_max,
+            step=0.01,
+            description="PCy",
+            style=style,
+        ),
+        "pcz": ipywidgets.FloatSlider(
+            value=pcz,
+            min=pz_min,
+            max=pz_max,
+            step=0.01,
+            description="PCz",
+            style=style,
+        ),
+    }
 
-        # TODO: Look into blitting instead of clearing everything
-        ax.clear()
-
-        plot_ebsd_detector_geometry_side_view(
-            det, ax=ax, annotate=annotate, dimensionless=dimensionless
-        )
-
-        fig.canvas.draw_idle()
-
-    for s in [s_st, s_dt, s_px, s_py, s_pz]:
-        s.observe(update, names="value")
-
-    update()
-
-    widget = widgets.VBox([s_st, s_dt, s_px, s_py, s_pz])
-
-    return fig, widget
+    return sliders

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -17,7 +17,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""Private functions for plotting an EBSD detector and projection centers."""
+"""Plotting an EBSD detector and projection centers."""
 
 from typing import Any, Literal
 

--- a/src/kikuchipy/draw/_plot_ebsd_detector.py
+++ b/src/kikuchipy/draw/_plot_ebsd_detector.py
@@ -447,21 +447,28 @@ def plot_ebsd_detector_geometry_side_view(
         zorder=0,
     )
 
-    ax.set_aspect("equal")
-
     # Handle axis orientation: Y axis as x-coordinate, Z as
     # y-coordinate, Z pointing down
+    ax.set_aspect("equal")
     ax.invert_yaxis()
     ax.invert_xaxis()
 
     if annotate:
-        ax.text(beam_start[0], beam_start[1], "Beam", ha="center", va="bottom")
+        ax.text(
+            beam_start[0],
+            beam_start[1],
+            "Beam",
+            ha="center",
+            va="bottom",
+            label="beam_annotation",
+        )
         ax.text(
             sample_start[0],
             sample_end[1],
             "Sample",
             ha="right",
             va="center",
+            label="sample_annotation",
         )
         ax.annotate(
             "Detector",
@@ -470,6 +477,7 @@ def plot_ebsd_detector_geometry_side_view(
             textcoords="offset points",
             ha="center",
             va="top",
+            label="detector_annotation",
         )
         ax.annotate(
             "PC",
@@ -478,6 +486,7 @@ def plot_ebsd_detector_geometry_side_view(
             textcoords="offset points",
             ha="left",
             va="top",
+            label="pc_annotation",
         )
 
     if dimensionless:

--- a/src/kikuchipy/indexing/_hough_indexing.py
+++ b/src/kikuchipy/indexing/_hough_indexing.py
@@ -32,7 +32,7 @@ import numpy as np
 from orix.crystal_map import CrystalMap, PhaseList, create_coordinate_arrays
 from orix.quaternion import Rotation
 
-from kikuchipy._constants import dependency_version
+from kikuchipy._constants import dependency_version, verify_dependency_or_raise
 
 if TYPE_CHECKING:  # pragma: no cover
     if dependency_version["pyebsdindex"] is not None:
@@ -165,11 +165,7 @@ def _get_indexer_from_detector(
     Requires that :mod:`pyebsdindex` is installed, which is an optional
     dependency of kikuchipy. See :ref:`dependencies` for details.
     """
-    if dependency_version["pyebsdindex"] is None:  # pragma: no cover
-        raise ValueError(
-            "pyebsdindex must be installed. Install with pip install pyebsdindex. "
-            "See https://kikuchipy.org/en/stable/user/installation.html for details."
-        )
+    verify_dependency_or_raise("pyebsdindex", "Getting a PyEBSDIndex indexer")
 
     from pyebsdindex.ebsd_index import EBSDIndexer
 

--- a/src/kikuchipy/indexing/_hough_indexing.py
+++ b/src/kikuchipy/indexing/_hough_indexing.py
@@ -165,7 +165,7 @@ def _get_indexer_from_detector(
     Requires that :mod:`pyebsdindex` is installed, which is an optional
     dependency of kikuchipy. See :ref:`dependencies` for details.
     """
-    verify_dependency_or_raise("pyebsdindex", "Getting a PyEBSDIndex indexer")
+    verify_dependency_or_raise("pyebsdindex", "Getting an indexer")
 
     from pyebsdindex.ebsd_index import EBSDIndexer
 

--- a/src/kikuchipy/indexing/_refinement/_refinement.py
+++ b/src/kikuchipy/indexing/_refinement/_refinement.py
@@ -33,6 +33,7 @@ from orix.crystal_map import CrystalMap, Phase, PhaseList, create_coordinate_arr
 from orix.quaternion import Rotation
 import scipy.optimize
 
+from kikuchipy._constants import dependency_version, verify_dependency_or_raise
 from kikuchipy.indexing._refinement import SUPPORTED_OPTIMIZATION_METHODS
 from kikuchipy.indexing._refinement._solvers import (
     _refine_orientation_pc_solver_nlopt,
@@ -47,7 +48,6 @@ from kikuchipy.signals.util._crystal_map import _get_indexed_points_in_data_in_x
 from kikuchipy.signals.util._master_pattern import _get_direction_cosines_from_detector
 
 if TYPE_CHECKING:  # pragma: no cover
-    from kikuchipy._constants import dependency_version
     from kikuchipy.detectors._ebsd_detector import EBSDDetector
     from kikuchipy.signals.ebsd_master_pattern import EBSDMasterPattern
 
@@ -1083,7 +1083,7 @@ class _RefinementSetup:
 
         if method not in supported_methods:
             raise ValueError(
-                f"Method '{method}' not in the list of supported methods "
+                f"Method {method!r} not in the list of supported methods "
                 f"{supported_methods}"
             )
 
@@ -1093,14 +1093,8 @@ class _RefinementSetup:
         self.package = method_dict["package"]
 
         if self.package == "nlopt":
-            from kikuchipy._constants import dependency_version
-
             method_upper = method.upper()
-            if dependency_version["nlopt"] is None:
-                raise ImportError(  # pragma: no cover
-                    f"Package `nlopt`, required for method {method_upper}, is not "
-                    "installed"
-                )
+            verify_dependency_or_raise("nlopt", f"Optimization method {method_upper}!")
 
             import nlopt
 

--- a/src/kikuchipy/indexing/_refinement/_refinement.py
+++ b/src/kikuchipy/indexing/_refinement/_refinement.py
@@ -1094,7 +1094,7 @@ class _RefinementSetup:
 
         if self.package == "nlopt":
             method_upper = method.upper()
-            verify_dependency_or_raise("nlopt", f"Optimization method {method_upper}!")
+            verify_dependency_or_raise("nlopt", f"Optimization method {method_upper!r}")
 
             import nlopt
 

--- a/src/kikuchipy/signals/_kikuchi_master_pattern.py
+++ b/src/kikuchipy/signals/_kikuchi_master_pattern.py
@@ -25,11 +25,12 @@ from warnings import warn
 import hyperspy.api as hs
 import numpy as np
 from orix.crystal_map import Phase
-from orix.projections import StereographicProjection
+from orix.projections import InverseStereographicProjection, StereographicProjection
 from orix.vector import Vector3d
 from scipy.interpolate import interpn
 from tqdm import tqdm
 
+from kikuchipy._constants import verify_dependency_or_raise
 from kikuchipy._utils.vector import (
     ValidHemispheres,
     ValidProjections,
@@ -262,16 +263,9 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
         >>> mp = kp.data.nickel_ebsd_master_pattern_small(projection="stereographic")
         >>> mp.plot_spherical()
         """
-        from kikuchipy._constants import dependency_version
+        verify_dependency_or_raise("pyvista", "3D plotting on the sphere")
 
-        if dependency_version["pyvista"] is None:  # pragma: no cover
-            raise ImportError(
-                "PyVista is required, see the installation guide for more information"
-            )
-        else:
-            from orix.projections import InverseStereographicProjection
-            from orix.vector import Vector3d
-            import pyvista as pv
+        import pyvista as pv
 
         if self.projection != "stereographic" or (
             self.hemisphere != "both" and not self.phase.point_group.contains_inversion

--- a/src/kikuchipy/signals/ebsd.py
+++ b/src/kikuchipy/signals/ebsd.py
@@ -43,7 +43,7 @@ from orix.quaternion import Rotation
 from scipy.ndimage import correlate, gaussian_filter
 from skimage.util.dtype import dtype_range
 
-from kikuchipy._constants import dependency_version, pyopencl_context_available
+from kikuchipy._constants import pyopencl_context_available, verify_dependency_or_raise
 from kikuchipy.detectors._ebsd_detector import EBSDDetector
 from kikuchipy.filters.fft_barnes import _fft_filter, _fft_filter_setup
 from kikuchipy.filters.window import Window
@@ -1670,12 +1670,8 @@ class EBSD(KikuchipySignal2D):
         uses a single thread. If you need the fastest indexing, refer to
         the PyEBSDIndex documentation for multi-threading and more.
         """
-        if dependency_version["pyebsdindex"] is None:  # pragma: no cover
-            raise ValueError(
-                "Hough indexing requires pyebsdindex to be installed. Install it with "
-                "pip install pyebsdindex. See "
-                "https://kikuchipy.org/en/stable/user/installation.html for details"
-            )
+        verify_dependency_or_raise("pyebsdindex", "Hough indexing")
+
         if self._lazy and not pyopencl_context_available:  # pragma: no cover
             raise ValueError(
                 "Hough indexing of lazy signals must use PyOpenCL, which must be able "
@@ -1768,12 +1764,10 @@ class EBSD(KikuchipySignal2D):
         Requires :mod:`pyebsdindex` to be installed. See
         :ref:`dependencies` for further details.
         """
-        if dependency_version["pyebsdindex"] is None:  # pragma: no cover
-            raise ValueError(
-                "Hough indexing requires pyebsdindex to be installed. Install it with "
-                "pip install pyebsdindex. See "
-                "https://kikuchipy.org/en/stable/user/installation.html for details"
-            )
+        verify_dependency_or_raise(
+            "pyebsdindex", "Projection center optimization with Hough indexing"
+        )
+
         if self._lazy and not pyopencl_context_available:  # pragma: no cover
             raise ValueError(
                 "Hough indexing of lazy signals must use PyOpenCL, which must be able "

--- a/src/kikuchipy/signals/ebsd.py
+++ b/src/kikuchipy/signals/ebsd.py
@@ -403,6 +403,7 @@ class EBSD(KikuchipySignal2D):
         >>> s.axes_manager['x'].scale
         2.0
         """
+        # TODO: Update crystal map step size too
         x, y = self.axes_manager.navigation_axes
         x.name, y.name = ("x", "y")
         x.scale, y.scale = (step_x, step_y)
@@ -431,6 +432,7 @@ class EBSD(KikuchipySignal2D):
         >>> s.axes_manager['dx'].scale
         70.0
         """
+        # TODO: Update detector pixel size too
         center = delta * np.array(self.axes_manager.signal_shape) / 2
         dx, dy = self.axes_manager.signal_axes
         dx.units, dy.units = ["um"] * 2

--- a/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
+++ b/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
@@ -73,7 +73,7 @@ from orix.quaternion import Rotation
 from orix.vector import Vector3d
 from tqdm import tqdm
 
-from kikuchipy._constants import dependency_version
+from kikuchipy._constants import verify_dependency_or_raise
 from kikuchipy._utils.numba import vec_dot
 from kikuchipy._utils.vector import ValidHemispheres, poles_from_hemisphere
 from kikuchipy.detectors._ebsd_detector import EBSDDetector
@@ -457,12 +457,8 @@ class KikuchiPatternSimulator:
             :class:`~matplotlib.figure.Figure` or a
             :class:`~pyvista.Plotter` is returned.
         """
-        if (
-            projection == "spherical"
-            and backend == "pyvista"
-            and dependency_version["pyvista"] is None
-        ):  # pragma: no cover
-            raise ImportError("PyVista is not installed")
+        if projection == "spherical" and backend == "pyvista":
+            verify_dependency_or_raise("pyvista", "3D spherical plot")
 
         ref = self._reflectors
 

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 
 import matplotlib.collections as mcollections
 import matplotlib.colors as mcolors
+import matplotlib.figure as mfigure
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
@@ -800,6 +801,26 @@ class TestPlotDetector:
             assert f"{expected_annotation_prefix}_annotation" in annotation_labels
         assert ax2.get_xlabel() == "Microscope Y axis [mm]"
         assert ax2.get_ylabel() == "Microscope Z axis [mm]"
+
+    @pytest.mark.skipif(
+        dependency_version["ipywidgets"] is None, reason="Needs ipywidgets"
+    )
+    def test_plot_side_view_interactive(self):
+        import ipywidgets
+
+        det = kp.detectors.EBSDDetector()
+        widgets1 = det.plot_side_view_interactive()
+        assert isinstance(widgets1, ipywidgets.VBox)
+
+        widgets2, fig1 = det.plot_side_view_interactive(
+            inplace=True, return_figure=True
+        )
+        assert isinstance(widgets2, ipywidgets.VBox)
+        assert isinstance(fig1, mfigure.Figure)
+
+        _, ax = plt.subplots()
+        _, fig3 = det.plot_side_view_interactive(ax=ax, return_figure=True)
+        assert fig3.axes[0] is ax
 
 
 class TestPlotPC:

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -780,6 +780,28 @@ class TestEBSDDetector:
             det.binning = (3, 4)
 
 
+class TestPlotDetector:
+    def test_plot_side_view(self):
+        det = kp.detectors.EBSDDetector()
+
+        fig1 = det.plot_side_view(return_figure=True)
+        ax1 = fig1.axes[0]
+        line_labels = [line.get_label() for line in ax1.lines]
+        for expected_label in ["Sample", "PC", "Detector"]:
+            assert expected_label in line_labels
+        assert len(ax1.texts) == 1
+        assert ax1.get_xlabel() == ""
+
+        fig2 = plt.figure()
+        ax2 = fig2.add_subplot()
+        det.plot_side_view(ax=ax2, annotate=True, dimensionless=False)
+        annotation_labels = [text.get_label() for text in ax2.texts]
+        for expected_annotation_prefix in ["sample", "beam", "detector", "pc"]:
+            assert f"{expected_annotation_prefix}_annotation" in annotation_labels
+        assert ax2.get_xlabel() == "Microscope Y axis [mm]"
+        assert ax2.get_ylabel() == "Microscope Z axis [mm]"
+
+
 class TestPlotPC:
     det = kp.detectors.EBSDDetector(
         shape=(60, 60),

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -551,8 +551,8 @@ class TestEBSDDetector:
             kwargs["coordinates"] = coordinates
         fig = detector.plot(**kwargs)
         ax = fig.axes[0]
-        assert ax.get_xlabel() == f"x {desired_label}"
-        assert ax.get_ylabel() == f"y {desired_label}"
+        assert ax.get_xlabel() == f"{desired_label.capitalize()} X"
+        assert ax.get_ylabel() == f"{desired_label.capitalize()} Y"
         if isinstance(pattern, np.ndarray):
             assert np.allclose(ax.get_images()[0].get_array(), pattern)
         plt.close("all")
@@ -788,18 +788,17 @@ class TestPlotDetector:
         fig1 = det.plot_side_view(return_figure=True)
         ax1 = fig1.axes[0]
         line_labels = [line.get_label() for line in ax1.lines]
-        for expected_label in ["Sample", "PC", "Detector"]:
-            assert expected_label in line_labels
+        assert all(expected in line_labels for expected in ["Sample", "Detector"])
+        assert "PC" in [coll.get_label() for coll in ax1.collections]
         assert len(ax1.texts) == 1
         assert ax1.get_xlabel() == "Microscope Y"
         assert ax1.get_ylabel() == "Microscope Z"
 
         fig2 = plt.figure()
         ax2 = fig2.add_subplot()
-        det.plot_side_view(ax=ax2, annotate=True, dimensionless=False)
-        annotation_labels = [text.get_label() for text in ax2.texts]
-        for expected_annotation_prefix in ["sample", "beam", "detector", "pc"]:
-            assert f"{expected_annotation_prefix}_annotation" in annotation_labels
+        det.plot_side_view(ax=ax2, legend=True, dimensionless=False)
+        legend = fig2.legend()
+        assert len(legend.legend_handles) == 3
         assert ax2.get_xlabel() == "Microscope Y [mm]"
         assert ax2.get_ylabel() == "Microscope Z [mm]"
 

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -27,6 +27,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from orix.crystal_map import PhaseList
 from orix.quaternion import Rotation
+from packaging.version import Version
 import pytest
 
 import kikuchipy as kp
@@ -798,7 +799,10 @@ class TestPlotDetector:
         ax2 = fig2.add_subplot()
         det.plot_side_view(ax=ax2, legend=True, dimensionless=False)
         legend = fig2.legend()
-        assert len(legend.legend_handles) == 3
+        if dependency_version["matplotlib"] >= Version("3.7"):
+            assert len(legend.legend_handles) == 3
+        else:
+            assert len(legend.legendHandles) == 3
         assert ax2.get_xlabel() == "Microscope Y [mm]"
         assert ax2.get_ylabel() == "Microscope Z [mm]"
 

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -791,7 +791,8 @@ class TestPlotDetector:
         for expected_label in ["Sample", "PC", "Detector"]:
             assert expected_label in line_labels
         assert len(ax1.texts) == 1
-        assert ax1.get_xlabel() == ""
+        assert ax1.get_xlabel() == "Microscope Y"
+        assert ax1.get_ylabel() == "Microscope Z"
 
         fig2 = plt.figure()
         ax2 = fig2.add_subplot()
@@ -799,8 +800,8 @@ class TestPlotDetector:
         annotation_labels = [text.get_label() for text in ax2.texts]
         for expected_annotation_prefix in ["sample", "beam", "detector", "pc"]:
             assert f"{expected_annotation_prefix}_annotation" in annotation_labels
-        assert ax2.get_xlabel() == "Microscope Y axis [mm]"
-        assert ax2.get_ylabel() == "Microscope Z axis [mm]"
+        assert ax2.get_xlabel() == "Microscope Y [mm]"
+        assert ax2.get_ylabel() == "Microscope Z [mm]"
 
     @pytest.mark.skipif(
         dependency_version["ipywidgets"] is None, reason="Needs ipywidgets"

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -810,17 +810,15 @@ class TestPlotDetector:
         import ipywidgets
 
         det = kp.detectors.EBSDDetector()
-        widgets1 = det.plot_side_view_interactive()
+        widgets1 = det.plot_side_view(interactive=True)
         assert isinstance(widgets1, ipywidgets.VBox)
 
-        widgets2, fig1 = det.plot_side_view_interactive(
-            inplace=True, return_figure=True
-        )
+        widgets2, fig1 = det.plot_side_view(interactive=True, return_figure=True)
         assert isinstance(widgets2, ipywidgets.VBox)
         assert isinstance(fig1, mfigure.Figure)
 
         _, ax = plt.subplots()
-        _, fig3 = det.plot_side_view_interactive(ax=ax, return_figure=True)
+        _, fig3 = det.plot_side_view(interactive=True, ax=ax, return_figure=True)
         assert fig3.axes[0] is ax
 
 

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -1249,7 +1249,7 @@ class TestGetIndexer:
     )
     def test_get_indexer_raises(self):
         pl = PhaseList(names=["al", "si"], space_groups=[225, 227])
-        with pytest.raises(ValueError, match="pyebsdindex must be installed. Install "):
+        with pytest.raises(ImportError, match="requires that 'pyebsdindex'"):
             _ = self.det.get_indexer(pl)
 
     @pytest.mark.skipif(

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -631,7 +631,7 @@ class TestEBSDDetector:
         """Pass PC kwargs to scatter()."""
         fig = detector.plot(show_pc=True, pc_kwargs=pc_kwargs, return_figure=True)
         if pc_kwargs is None:
-            pc_kwargs = {"facecolor": "gold"}
+            pc_kwargs = {"facecolor": "C1"}
         assert np.allclose(
             fig.axes[0].collections[0].get_facecolor().squeeze()[:3],
             mcolors.to_rgb(pc_kwargs["facecolor"]),

--- a/tests/test_indexing/test_ebsd_refinement.py
+++ b/tests/test_indexing/test_ebsd_refinement.py
@@ -227,7 +227,7 @@ class TestEBSDRefine(EBSDRefineTestSetup):
         )
         det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
 
-        with pytest.raises(ImportError, match="Package `nlopt`, required for method "):
+        with pytest.raises(ImportError, match="Optimization method 'LN_NELDERMEAD' "):
             _ = s.refine_orientation_projection_center(
                 xmap=xmap,
                 master_pattern=self.mp,

--- a/tests/test_io/test_kikuchipy_h5ebsd.py
+++ b/tests/test_io/test_kikuchipy_h5ebsd.py
@@ -137,7 +137,9 @@ class TestKikuchipyH5EBSD:
 
         with pytest.warns(UserWarning) as warninfo:
             s_reload = kp.load(save_path_hdf5, lazy=lazy)
-        assert len(warninfo) == 2
+        messages = [str(w.message) for w in warninfo]
+        for expected_message in ["Signal shape (60, 60)", "Data navigation shape"]:
+            assert any(expected_message in msg for msg in messages)
 
         ni_small_axes_manager["axis-1"]["size"] = new_n_columns
         assert_dictionary_func(

--- a/tests/test_signals/test_ebsd_hough_indexing.py
+++ b/tests/test_signals/test_ebsd_hough_indexing.py
@@ -377,13 +377,13 @@ class TestHoughIndexingNoPyEBSDIndex:
         self.signal = s
 
     def test_get_indexer(self):
-        with pytest.raises(ValueError, match="pyebsdindex must be installed"):
+        with pytest.raises(ImportError, match="requires that 'pyebsdindex'"):
             _ = self.signal.detector.get_indexer(None)
 
     def test_hough_indexing_raises_pyebsdindex(self):
-        with pytest.raises(ValueError, match="pyebsdindex to be installed"):
+        with pytest.raises(ImportError, match="requires that 'pyebsdindex'"):
             _ = self.signal.hough_indexing(None, None)
 
     def test_optimize_pc_raises_pyebsdindex(self):
-        with pytest.raises(ValueError, match="pyebsdindex to be installed"):
+        with pytest.raises(ImportError, match="requires that 'pyebsdindex' "):
             _ = self.signal.hough_indexing_optimize_pc(None, None)

--- a/tests/test_simulations/test_kikuchi_pattern_simulator.py
+++ b/tests/test_simulations/test_kikuchi_pattern_simulator.py
@@ -340,7 +340,7 @@ class TestPlot:
         """Appropriate error message is raised when PyVista is
         unavailable.
         """
-        with pytest.raises(ImportError, match="PyVista is not installed"):
+        with pytest.raises(ImportError, match="3D spherical plot requires that"):
             _ = self.simulator.plot("spherical", backend="pyvista")
 
     def test_plot_scaling(self):


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR adds interactive EBSD detector plots to aid in the understanding of the detector-sample geometry parameters:
- sample tilt
- detector tilt
- detector azimuthal (about microscope Z)
- projection center (x, y, z)

This adds a dependency on ipywidgets.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)
- [x] Add gnomonic circles to detector plane (illustrative when changing PCz)
- [x] Fixed size of plot axis bounds (currently changes too much when moving sliders)
- [x] Reasonable bounds for the parameters (avoid collisions and so that objects look in proportion and in the right place relative to each other)

#### Minimal example of the bug fix or new feature
```python
from IPython.display import display
import kikuchipy as kp

det = kp.detectors.EBSDDetector(
    shape=(60, 60),
    pc=[0.3, 0.2, 0.5],
    px_size=70,  # Microns
    binning=8,
    tilt=0,
    sample_tilt=70,
    azimuthal=5,
)
widgets = det.plot_interactive(figsize=(6, 2), dimensionless=False)
display(widgets)  # In general unnecessary in an IPython kernel
```

https://github.com/user-attachments/assets/814d95e0-8a10-40d3-a20e-d42c7f3f1495

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
