### PR TITLE
Improve data module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Unreleased
 
 Added
 -----
+- More master patterns downloadable to a local cache via ``data.ebsd_master_pattern()``:
+  Alternative sigma (Fe-Cr-Mo), Cr2N, R (Fe-Cr-Mo), Pi (Fe-Mo), Al6Mn, and alpha-AlMnSi.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Added
 -----
 - More master patterns downloadable to a local cache via ``data.ebsd_master_pattern()``:
   Alternative sigma (Fe-Cr-Mo), Cr2N, R (Fe-Cr-Mo), Pi (Fe-Mo), Al6Mn, and alpha-AlMnSi.
+  (`#796 <https://github.com/pyxem/kikuchipy/pull/796>`_)
+- Function to clear the kikuchipy data cache directory.
+  (`#796 <https://github.com/pyxem/kikuchipy/pull/796>`_)
 
 Changed
 -------

--- a/conftest.py
+++ b/conftest.py
@@ -104,6 +104,9 @@ def skipif_no_vtk_support():
 
 def pytest_sessionstart(session):
     _ = kp.data.nickel_ebsd_large(allow_download=True)
+    _ = kp.data.si_ebsd_moving_screen(0, allow_download=True)
+    _ = kp.data.si_ebsd_moving_screen(5, allow_download=True)
+    _ = kp.data.si_ebsd_moving_screen(10, allow_download=True)
     plt.rcParams.update({"backend": "agg", "figure.max_open_warning": False})
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,7 @@ import pytest
 
 import kikuchipy as kp
 from kikuchipy._constants import dependency_version
-from kikuchipy.data._data import marshall
+from kikuchipy.data._data import get_fetching_pooch
 from kikuchipy.data._dummy_files.bruker_h5ebsd import (
     create_dummy_bruker_h5ebsd_file,
     create_dummy_bruker_h5ebsd_nonrectangular_roi_file,
@@ -410,6 +410,7 @@ def kikuchipy_h5ebsd_path() -> Generator[Path, None, None]:
 
 @pytest.fixture
 def nickel_ebsd_large_h5ebsd_renamed() -> Generator[Path, None, None]:
+    marshall = get_fetching_pooch()
     f1 = Path(marshall.path) / "data/nickel_ebsd_large/patterns.h5"
     f2 = f1.rename(f1.with_suffix(".bak"))
     yield f2

--- a/doc/dev/adding_to_data_module.rst
+++ b/doc/dev/adding_to_data_module.rst
@@ -5,23 +5,28 @@ Adding data to the data module
 
 Example datasets used in the documentation and tests are included in the
 :mod:`kikuchipy.data` module via the `pooch <https://www.fatiando.org/pooch/latest/>`__
-Python library. These are listed in a file registry (``kikuchipy.data._registry.py``)
-with their file verification string (hash, MD5, obtain with e.g. ``md5sum <file>``) and
-location, the latter potentially not within the package but from the `kikuchipy-data
+Python library.
+These are listed in a file registry (``kikuchipy.data._registry.py``) with their file
+verification string (hash, MD5, obtain with e.g. ``md5sum <file>``) and location, the
+latter potentially not within the package but from the `kikuchipy-data
 <https://github.com/pyxem/kikuchipy-data>`__ repository or elsewhere, since some files
 are considered too large to include in the package.
 
 If a required dataset isn't in the package, but is in the registry, it can be downloaded
 from the repository when the user passes ``allow_download=True`` to e.g.
-:func:`~kikuchipy.data.nickel_ebsd_large`. The dataset is then downloaded to a local
-cache, in the location returned from ``pooch.os_cache("kikuchipy")``. The location can
-be set with a global `KIKUCHIPY_DATA_DIR` variable locally, e.g. by setting
-``export KIKUCHIPY_DATA_DIR=~/kikuchipy_data`` in ``~/.bashrc``. Pooch handles
-downloading, caching, version control, file verification (against hash) etc. of files
-not included in the package. If we have updated the file hash, pooch will re-download
-it. If the file is available in the cache, it can be loaded as the other files in the
-data module.
+:func:`~kikuchipy.data.nickel_ebsd_large`.
+This requires that :doc:`pooch <pooch:api/index>` is installed.
+The dataset is then downloaded to a local cache, in the location returned from
+``pooch.os_cache("kikuchipy")``.
+The location can be set with a global `KIKUCHIPY_DATA_DIR` variable locally, e.g. by
+setting ``export KIKUCHIPY_DATA_DIR=~/kikuchipy_data`` in ``~/.bashrc``.
+Pooch handles downloading, caching, version control, file verification (against hash)
+etc. of files not included in the package.
+If we have updated the file hash, pooch will re-download it.
+If the file is available in the cache, it can be loaded as the other files in the data
+module.
 
 With every new version of kikuchipy, a new directory of datasets with the version name
-is added to the cache directory. Any old directories are not deleted automatically, and
-should then be deleted manually if desired.
+is added to the cache directory.
+Any old directories are not deleted automatically, and should then be deleted manually
+if desired.

--- a/doc/dev/adding_to_data_module.rst
+++ b/doc/dev/adding_to_data_module.rst
@@ -15,7 +15,7 @@ are considered too large to include in the package.
 If a required dataset isn't in the package, but is in the registry, it can be downloaded
 from the repository when the user passes ``allow_download=True`` to e.g.
 :func:`~kikuchipy.data.nickel_ebsd_large`.
-This requires that :doc:`pooch <pooch:api/index>` is installed.
+This requires that :mod:`pooch` is installed.
 The dataset is then downloaded to a local cache, in the location returned from
 ``pooch.os_cache("kikuchipy")``.
 The location can be set with a global `KIKUCHIPY_DATA_DIR` variable locally, e.g. by

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -98,29 +98,28 @@ Dependencies
 kikuchipy builds on the great work and effort of many people.
 This is a list of core package dependencies:
 
-* :doc:`dask <dask:index>`: Out-of-memory processing of data larger than RAM
-* :doc:`diffpy.structure <diffpy.structure:index>`: Handling of crystal structures
+* :doc:`dask <dask:index>`: Out-of-memory processing of data larger than RAM.
+* :doc:`diffpy.structure <diffpy.structure:index>`: Handling of crystal structures.
 * :doc:`diffsims <diffsims:index>`: Handling of reciprocal lattice vectors and structure
-  factors
-* :doc:`hyperspy <hyperspy:index>`: Multi-dimensional data handling (EBSD class etc.)
-* :doc:`h5py <h5py:index>`: Read/write of HDF5 files
-* :doc:`imageio <imageio:index>`: Read image formats
-* `lazy_loader`_: Lazy loading of functions, classes, and modules
-* :doc:`matplotlib <matplotlib:index>`: Visualization
-* :doc:`numba <numba:index>`: CPU acceleration via just-in-time compilation
-* :doc:`numpy <numpy:index>`: Handling of N-dimensional arrays
-* :doc:`packaging <packaging:index>`: Version comparison
-* :doc:`orix <orix:index>`: Handling of rotations and vectors using crystal symmetry
-* :doc:`pooch <pooch:api/index>`: Downloading and caching of datasets
-* `pyyaml <https://pyyaml.org/>`__: Parcing of YAML files
+  factors.
+* :doc:`hyperspy <hyperspy:index>`: Multi-dimensional data handling (EBSD class etc.).
+* :doc:`h5py <h5py:index>`: Read/write of HDF5 files.
+* :doc:`imageio <imageio:index>`: Read image formats.
+* `lazy_loader`_: Lazy loading of functions, classes, and modules.
+* :doc:`matplotlib <matplotlib:index>`: Visualization.
+* :doc:`numba <numba:index>`: CPU acceleration via just-in-time compilation.
+* :doc:`numpy <numpy:index>`: Handling of N-dimensional arrays.
+* :doc:`packaging <packaging:index>`: Version comparison.
+* :doc:`orix <orix:index>`: Handling of rotations and vectors using crystal symmetry.
+* `pyyaml <https://pyyaml.org/>`__: Parcing of YAML files.
 * :doc:`scikit-image <skimage:index>`: Image processing like adaptive histogram
-  equalization
-* :doc:`rosettasciio <rosettasciio:index>`: Read/write of some file formats
-* `scikit-learn <https://scikit-learn.org/stable/>`__: Multivariate analysis
-* :doc:`scipy <scipy:index>`: Optimization algorithms, filtering and more
-* `tqdm <https://tqdm.github.io/>`__: Progressbars
+  equalization.
+* :doc:`rosettasciio <rosettasciio:index>`: Read/write of some file formats.
+* `scikit-learn <https://scikit-learn.org/stable/>`__: Multivariate analysis.
+* :doc:`scipy <scipy:index>`: Optimization algorithms, filtering and more.
+* `tqdm <https://tqdm.github.io/>`__: Progressbars.
 * :doc:`typing-extensions <typing-extensions:index>`: Type hints only available from
-  Python >= 3.11
+  Python >= 3.11.
 
 .. _lazy_loader: https://scientific-python.org/specs/spec-0001/#lazy_loader
 
@@ -128,14 +127,15 @@ Some functionality requires optional dependencies:
 
 * :doc:`ipywidgets <ipywidgets:index>`: Interactive widgets in Jupyter notebooks.
 * :doc:`IPython <ipython:index>`: Interactive widgets in Jupyter notebooks.
-* :doc:`psygnal <psygnal:index>`: Trigger actions based on state changes.
-* :doc:`pyebsdindex <pyebsdindex:index>`: Hough indexing.
   We recommend to install with optional GPU support via :doc:`pyopencl<pyopencl:index>`
   with ``pip install "pyebsdindex[gpu]""`` or
   ``conda install pyebsdindex -c conda-forge``.
 * `nlopt <https://nlopt.readthedocs.io/en/latest/NLopt_Python_Reference/>`__: Extra
   optimization algorithms used in EBSD orientation and/or projection center refinement.
   Installation from conda ``conda install nlopt -c conda-forge`` is recommended.
+* :doc:`pooch <pooch:api/index>`: Downloading and caching of datasets.
+* :doc:`psygnal <psygnal:index>`: Trigger actions based on state changes.
+* :doc:`pyebsdindex <pyebsdindex:index>`: Hough indexing.
 * :doc:`pyvista<pyvista:index>`: 3D plotting of master patterns.
 
 Note that installing with the optional dependencies, ``pip install "kikuchipy[all]"``,

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -134,9 +134,10 @@ Some functionality requires optional dependencies:
   optimization algorithms used in EBSD orientation and/or projection center refinement.
   Installation from conda ``conda install nlopt -c conda-forge`` is recommended.
 * :doc:`pooch <pooch:api/index>`: Downloading and caching of datasets.
-* :doc:`psygnal <psygnal:index>`: Trigger actions based on state changes.
+* :doc:`psygnal <https://psygnal.readthedocs.io>`: Trigger actions based on state
+  changes.
 * :doc:`pyebsdindex <pyebsdindex:index>`: Hough indexing.
-* :doc:`pyvista<pyvista:index>`: 3D plotting of master patterns.
+* :doc:`pyvista <pyvista:index>`: 3D plotting of master patterns.
 
 Note that installing with the optional dependencies, ``pip install "kikuchipy[all]"``,
 will not install ``pyopencl``, which is required for GPU support in ``pyebsdindex``.

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -126,17 +126,17 @@ This is a list of core package dependencies:
 Some functionality requires optional dependencies:
 
 * :doc:`ipywidgets <ipywidgets:index>`: Interactive widgets in Jupyter notebooks.
-* :doc:`IPython <ipython:index>`: Interactive widgets in Jupyter notebooks.
-  We recommend to install with optional GPU support via :doc:`pyopencl<pyopencl:index>`
-  with ``pip install "pyebsdindex[gpu]""`` or
-  ``conda install pyebsdindex -c conda-forge``.
+* `IPython <https://ipython.readthedocs.io>`__: Interactive widgets in Jupyter
+  notebooks.
 * `nlopt <https://nlopt.readthedocs.io/en/latest/NLopt_Python_Reference/>`__: Extra
   optimization algorithms used in EBSD orientation and/or projection center refinement.
   Installation from conda ``conda install nlopt -c conda-forge`` is recommended.
 * :doc:`pooch <pooch:api/index>`: Downloading and caching of datasets.
-* :doc:`psygnal <https://psygnal.readthedocs.io>`: Trigger actions based on state
-  changes.
+* `psygnal <https://psygnal.readthedocs.io>`__: Trigger actions based on state changes.
 * :doc:`pyebsdindex <pyebsdindex:index>`: Hough indexing.
+  We recommend to install with optional GPU support via :doc:`pyopencl<pyopencl:index>`
+  with ``pip install "pyebsdindex[gpu]"`` or
+  ``conda install pyebsdindex -c conda-forge``.
 * :doc:`pyvista <pyvista:index>`: 3D plotting of master patterns.
 
 Note that installing with the optional dependencies, ``pip install "kikuchipy[all]"``,

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -111,7 +111,7 @@ This is a list of core package dependencies:
 * :doc:`numpy <numpy:index>`: Handling of N-dimensional arrays.
 * :doc:`packaging <packaging:index>`: Version comparison.
 * :doc:`orix <orix:index>`: Handling of rotations and vectors using crystal symmetry.
-* `pyyaml <https://pyyaml.org/>`__: Parcing of YAML files.
+* `pyyaml <https://pyyaml.org/>`__: Parsing of YAML files.
 * :doc:`scikit-image <skimage:index>`: Image processing like adaptive histogram
   equalization.
 * :doc:`rosettasciio <rosettasciio:index>`: Read/write of some file formats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "numpy            >= 1.23.0",
     "orix             >= 0.12.1",
     "packaging",
-    "pooch            >= 1.3.0",
     "pyyaml",
     "rosettasciio     >= 0.3.0",
     "scikit-image     >= 0.16.2",
@@ -69,6 +68,7 @@ all = [
     "ipywidgets",
     "IPython",
     "nlopt",
+    "pooch >= 1.3.0",
     "psygnal",
     "pyebsdindex >= 0.3.9.2",
     "pyvista",
@@ -95,6 +95,7 @@ doc = [
 ]
 tests = [
     "numpydoc",
+    "pooch",
     "pytest                       >= 5.4",
     "pytest-benchmark",
     "pytest-rerunfailures",

--- a/src/kikuchipy/_constants.py
+++ b/src/kikuchipy/_constants.py
@@ -35,6 +35,7 @@ deps_for_version_check = [
     "IPython",
     "ipywidgets",
     "nlopt",
+    "pooch",
     "psygnal",
     "pyvista",
     "pyebsdindex",

--- a/src/kikuchipy/data/__init__.py
+++ b/src/kikuchipy/data/__init__.py
@@ -24,8 +24,9 @@ downloaded from the web. For more test datasets, see
 :doc:`/user/open_datasets`.
 
 Datasets are placed in a local cache, in the location returned from
-``pooch.os_cache("kikuchipy")`` by default. The location can be
-overwritten with a global ``KIKUCHIPY_DATA_DIR`` environment variable.
+``pooch.os_cache("kikuchipy")`` by default (requires the optional
+:doc:`pooch <pooch:api/index>` package). The location can be overwritten
+with a global ``KIKUCHIPY_DATA_DIR`` environment variable.
 
 With every new version of kikuchipy, a new directory of datasets with
 the version name is added to the cache directory. Any old directories
@@ -33,7 +34,8 @@ are not deleted automatically, and should then be deleted manually if
 desired.
 
 The cache directory can be cleared of all files by calling
-:func:`~kikuchipy.data.clear_cache`.
+:func:`~kikuchipy.data.clear_cache` (requires the optional
+:doc:`pooch <pooch:api/index>` package).
 """
 
 import lazy_loader

--- a/src/kikuchipy/data/__init__.py
+++ b/src/kikuchipy/data/__init__.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2026 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 """Example datasets for use when testing functionality.
 
@@ -29,6 +31,9 @@ With every new version of kikuchipy, a new directory of datasets with
 the version name is added to the cache directory. Any old directories
 are not deleted automatically, and should then be deleted manually if
 desired.
+
+The cache directory can be cleared of all files by calling
+:func:`~kikuchipy.data.clear_cache`.
 """
 
 import lazy_loader

--- a/src/kikuchipy/data/__init__.py
+++ b/src/kikuchipy/data/__init__.py
@@ -25,8 +25,9 @@ downloaded from the web. For more test datasets, see
 
 Datasets are placed in a local cache, in the location returned from
 ``pooch.os_cache("kikuchipy")`` by default (requires the optional
-:doc:`pooch <pooch:api/index>` package). The location can be overwritten
-with a global ``KIKUCHIPY_DATA_DIR`` environment variable.
+:mod:`pooch` package).
+The location can be overwritten with a global ``KIKUCHIPY_DATA_DIR``
+environment variable.
 
 With every new version of kikuchipy, a new directory of datasets with
 the version name is added to the cache directory. Any old directories
@@ -34,8 +35,8 @@ are not deleted automatically, and should then be deleted manually if
 desired.
 
 The cache directory can be cleared of all files by calling
-:func:`~kikuchipy.data.clear_cache` (requires the optional
-:doc:`pooch <pooch:api/index>` package).
+:func:`~kikuchipy.data.clear_cache` (requires the optional :mod:`pooch`
+package).
 """
 
 import lazy_loader

--- a/src/kikuchipy/data/__init__.pyi
+++ b/src/kikuchipy/data/__init__.pyi
@@ -16,6 +16,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from ._data import (
+    clear_cache,
     ebsd_master_pattern,
     ni_gain,
     ni_gain_calibration,
@@ -27,6 +28,7 @@ from ._data import (
 )
 
 __all__ = [
+    "clear_cache",
     "ebsd_master_pattern",
     "ni_gain",
     "ni_gain_calibration",

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -570,8 +570,8 @@ def ebsd_master_pattern(
     austenite     Austenite     :math:`\gamma`-Fe      10-20         0.3             10.5281/zenodo.7628387
     ferrite       Ferrite       :math:`\alpha`-Fe      5-20          0.3             10.5281/zenodo.7628394
     steel_chi     Chi           Fe36Cr12Mo10           10-20         0.6             10.5281/zenodo.7628417
-    steel_sigma   Sigma         Fe-Cr                  5-20          1.5             10.5281/zenodo.7628443
-    steel_sigma2  Sigma2        Fe-Cr                  10-20         0.8             10.5281/zenodo.20376902
+    steel_sigma   Sigma         Fe-Cr-Mo               5-20          1.5             10.5281/zenodo.7628443
+    steel_sigma2  Sigma2        Fe-Cr-Mo               10-20         0.8             10.5281/zenodo.20376902
     steel_r       R             Fe-Cr-Mo               10-20         3.0             10.5281/zenodo.20376827
     steel_pi      Pi            Fe-Mo                  10-20         0.5             10.5281/zenodo.20376759
     steel_cr2n    Cr2N          Cr2N                   10-20         0.5             10.5281/zenodo.20376533

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 the kikuchipy developers
+# Copyright 2019-2026 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -460,7 +460,8 @@ def ebsd_master_pattern(
     ----------
     phase
         Name of available phase. Options are (see *Notes* for details):
-        ni, al, si, austenite, ferrite, steel_chi, steel_sigma.
+        ni, al, si, austenite, ferrite, steel_chi, steel_sigma,
+        steel_sigma2.
     allow_download
         Whether to allow downloading the dataset from the internet to
         the local cache with the pooch Python package. Default is
@@ -487,17 +488,20 @@ def ebsd_master_pattern(
     The master patterns are downloaded in HDF5 files (carrying a CC BY
     4.0 license) from Zenodo.
 
-    ===========  =========  =================  ============  ==============  ======================
-    phase        Name       Symbol             Energy [keV]  File size [GB]  Zenodo DOI
-    ===========  =========  =================  ============  ==============  ======================
-    ni           nickel     Ni                 5-20          0.3             10.5281/zenodo.7628443
-    al           aluminium  Al                 10-20         0.2             10.5281/zenodo.7628365
-    si           silicon    Si                 5-20          0.3             10.5281/zenodo.7498729
-    austenite    austenite  :math:`\gamma`-Fe  10-20         0.3             10.5281/zenodo.7628387
-    ferrite      ferrite    :math:`\alpha`-Fe  5-20          0.3             10.5281/zenodo.7628394
-    steel_chi    chi        Fe36Cr15Mo7        10-20         0.6             10.5281/zenodo.7628417
-    steel_sigma  sigma      FeCr               5-20          1.5             10.5281/zenodo.7628443
-    ===========  =========  =================  ============  ==============  ======================
+    ============  =========  =================  ============  ==============  =======================
+    phase         Name       Symbol             Energy [keV]  File size [GB]  Zenodo DOI
+    ============  =========  =================  ============  ==============  =======================
+    ni            nickel     Ni                 5-20          0.3             10.5281/zenodo.7498644
+    al            aluminium  Al                 10-20         0.2             10.5281/zenodo.7628365
+    si            silicon    Si                 5-20          0.3             10.5281/zenodo.7498729
+    austenite     austenite  :math:`\gamma`-Fe  10-20         0.3             10.5281/zenodo.7628387
+    ferrite       ferrite    :math:`\alpha`-Fe  5-20          0.3             10.5281/zenodo.7628394
+    steel_chi     chi        Fe36Cr15Mo7        10-20         0.6             10.5281/zenodo.7628417
+    steel_sigma   sigma      FeCr               5-20          1.5             10.5281/zenodo.7628443
+    steel_sigma2  sigma2     FeCr               10-20         0.8             10.5281/zenodo.20376902
+    steel_r       R          FeCrMo             10-20         3.0             10.5281/zenodo.20376827
+    steel_pi      Pi         FeMo               10-20         0.5             10.5281/zenodo.20376759
+    ============  =========  =================  ============  ==============  =======================
 
     Examples
     --------
@@ -518,6 +522,9 @@ def ebsd_master_pattern(
         "ferrite": "ferrite_mc_mp_20kv.h5",
         "steel_chi": "steel_chi_mc_mp_20kv.h5",
         "steel_sigma": "steel_sigma_mc_mp_20kv.h5",
+        "steel_sigma2": "steel_sigma2_mc_mp_20kv.h5",
+        "steel_r": "r_mc_mp_20kv.h5",
+        "steel_pi": "pi_mc_mp_20kv.h5",
     }
 
     dset = Dataset("ebsd_master_pattern/" + datasets[phase.lower()])

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -488,20 +488,23 @@ def ebsd_master_pattern(
     The master patterns are downloaded in HDF5 files (carrying a CC BY
     4.0 license) from Zenodo.
 
-    ============  =========  =================  ============  ==============  =======================
-    phase         Name       Symbol             Energy [keV]  File size [GB]  Zenodo DOI
-    ============  =========  =================  ============  ==============  =======================
-    ni            nickel     Ni                 5-20          0.3             10.5281/zenodo.7498644
-    al            aluminium  Al                 10-20         0.2             10.5281/zenodo.7628365
-    si            silicon    Si                 5-20          0.3             10.5281/zenodo.7498729
-    austenite     austenite  :math:`\gamma`-Fe  10-20         0.3             10.5281/zenodo.7628387
-    ferrite       ferrite    :math:`\alpha`-Fe  5-20          0.3             10.5281/zenodo.7628394
-    steel_chi     chi        Fe36Cr15Mo7        10-20         0.6             10.5281/zenodo.7628417
-    steel_sigma   sigma      FeCr               5-20          1.5             10.5281/zenodo.7628443
-    steel_sigma2  sigma2     FeCr               10-20         0.8             10.5281/zenodo.20376902
-    steel_r       R          FeCrMo             10-20         3.0             10.5281/zenodo.20376827
-    steel_pi      Pi         FeMo               10-20         0.5             10.5281/zenodo.20376759
-    ============  =========  =================  ============  ==============  =======================
+    ============  ============  =====================  ============  ==============  =======================
+    phase         Name          Symbol                 Energy [keV]  File size [GB]  Zenodo DOI
+    ============  ============  =====================  ============  ==============  =======================
+    ni            Nickel        Ni                     5-20          0.3             10.5281/zenodo.7498644
+    al            Aluminium     Al                     10-20         0.2             10.5281/zenodo.7628365
+    si            Silicon       Si                     5-20          0.3             10.5281/zenodo.7498729
+    austenite     Austenite     :math:`\gamma`-Fe      10-20         0.3             10.5281/zenodo.7628387
+    ferrite       Ferrite       :math:`\alpha`-Fe      5-20          0.3             10.5281/zenodo.7628394
+    steel_chi     Chi           Fe36Cr12Mo10           10-20         0.6             10.5281/zenodo.7628417
+    steel_sigma   Sigma         Fe-Cr                  5-20          1.5             10.5281/zenodo.7628443
+    steel_sigma2  Sigma2        Fe-Cr                  10-20         0.8             10.5281/zenodo.20376902
+    steel_r       R             Fe-Cr-Mo               10-20         3.0             10.5281/zenodo.20376827
+    steel_pi      Pi            Fe-Mo                  10-20         0.5             10.5281/zenodo.20376759
+    steel_cr2n    Cr2N          Cr2N                   10-20         0.5             10.5281/zenodo.20376533
+    al6mn         Al6Mn         Al:math:`_6`Mn         10-20         0.5             10.5281/zenodo.20376067
+    alpha_almnsi  Alpha-AlMnSi  :math:`\alpha`-AlMnSi  10-20         1.1             10.5281/zenodo.20376378
+    ============  ============  =====================  ============  ==============  =======================
 
     Examples
     --------
@@ -525,6 +528,9 @@ def ebsd_master_pattern(
         "steel_sigma2": "steel_sigma2_mc_mp_20kv.h5",
         "steel_r": "r_mc_mp_20kv.h5",
         "steel_pi": "pi_mc_mp_20kv.h5",
+        "steel_cr2n": "cr2n_mc_mp_20kv.h5",
+        "al6mn": "al6mn_mc_mp_20kv.h5",
+        "alpha_almnsi": "alpha_almnsi_mc_mp_20kv.h5",
     }
 
     dset = Dataset("ebsd_master_pattern/" + datasets[phase.lower()])

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -58,7 +58,9 @@ def clear_cache() -> None:
     This deletes all directories and files in the kikuchipy data cache
     directory, located at ``pooch.os_cache("kikuchipy")``.
 
-    Requires the optional :doc:`pooch <pooch:api/index>` package.
+    .. note::
+
+        Requires the optional :mod:`pooch` package.
     """
     verify_dependency_or_raise("pooch", "Clearing the cache")
     import pooch
@@ -130,6 +132,10 @@ def nickel_ebsd_large(
     pixels from nickel, acquired on a NORDIF UF-1100 detector
     :cite:`aanes2019electron`.
 
+    .. note::
+
+        Requires the optional :mod:`pooch` package to be installed.
+
     Parameters
     ----------
     allow_download
@@ -182,6 +188,10 @@ def ni_gain(
     Ten datasets are available from the same region of interest,
     acquired with increasing gain on the detector, from no gain to
     maximum gain.
+
+    .. note::
+
+        Requires the optional :mod:`pooch` package to be installed.
 
     Parameters
     ----------
@@ -248,6 +258,10 @@ def ni_gain_calibration(
     The patterns are used to calibrate the detector-sample geometry
     of the datasets in :func:`~kikuchipy.data.ni_gain`. The calibration
     patterns were acquired with no gain on the detector.
+
+    .. note::
+
+        Requires the optional :mod:`pooch` package to be installed.
 
     Parameters
     ----------
@@ -320,6 +334,10 @@ def si_ebsd_moving_screen(
     They were acquired to test the moving-screen projection center
     estimation technique :cite:`hjelen1991electron`.
 
+    .. note::
+
+        Requires the optional :mod:`pooch` package to be installed.
+
     Parameters
     ----------
     distance
@@ -381,6 +399,10 @@ def si_wafer(
     projection centers (PCs), e.g. the moving-screen PC estimation
     technique :cite:`hjelen1991electron`. The EBSD pattern in
     :func:`silicon_ebsd_moving_screen_in` is from this dataset.
+
+    .. note::
+
+        Requires the optional :mod:`pooch` package to be installed.
 
     Parameters
     ----------
@@ -502,6 +524,10 @@ def ebsd_master_pattern(
 
     Master patterns were simulated with *EMsoft*
     :cite:`callahan2013dynamical`.
+
+    .. note::
+
+        Requires the optional :mod:`pooch` package to be installed.
 
     Parameters
     ----------

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -17,8 +17,10 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import logging
 import os
 from pathlib import Path
+import shutil
 
 import hyperspy.api as hs
 import pooch
@@ -28,6 +30,8 @@ from kikuchipy.data._registry import registry_hashes, registry_urls
 from kikuchipy.io._io import load
 from kikuchipy.signals.ebsd import EBSD
 from kikuchipy.signals.ebsd_master_pattern import EBSDMasterPattern
+
+_logger = logging.getLogger(__name__)
 
 marshall = pooch.create(
     path=pooch.os_cache("kikuchipy"),
@@ -39,6 +43,31 @@ marshall = pooch.create(
     urls=registry_urls,
     retry_if_failed=5,  # Five times at increasing intervals of 1 s
 )
+
+
+def _clear_directory(path: Path) -> None:
+    for item in path.iterdir():
+        if item.is_dir():
+            for file in item.rglob("*"):
+                if file.is_file():
+                    print(f"Deleting {file}")
+            shutil.rmtree(item)
+        else:
+            print(f"Deleting {item}")
+            item.unlink()
+
+
+def clear_cache() -> None:
+    """Clear the kikuchipy data cache directory.
+
+    This deletes all directories and files in the kikuchipy data cache
+    directory, located at ``pooch.os_cache("kikuchipy")``.
+    """
+    cache_dir = Path(os.environ.get("KIKUCHIPY_DATA_DIR", pooch.os_cache("kikuchipy")))
+    if cache_dir.exists():
+        _clear_directory(cache_dir)
+    else:
+        _logger.debug("Data cache directory does not exist")
 
 
 # ----------------------- Experimental datasets ---------------------- #
@@ -485,8 +514,8 @@ def ebsd_master_pattern(
 
     Notes
     -----
-    The master patterns are downloaded in HDF5 files (carrying a CC BY
-    4.0 license) from Zenodo.
+    The master patterns are downloaded in HDF5 files from Zenodo
+    (carrying a CC BY 4.0 license).
 
     ============  ============  =====================  ============  ==============  =======================
     phase         Name          Symbol                 Energy [keV]  File size [GB]  Zenodo DOI
@@ -502,7 +531,7 @@ def ebsd_master_pattern(
     steel_r       R             Fe-Cr-Mo               10-20         3.0             10.5281/zenodo.20376827
     steel_pi      Pi            Fe-Mo                  10-20         0.5             10.5281/zenodo.20376759
     steel_cr2n    Cr2N          Cr2N                   10-20         0.5             10.5281/zenodo.20376533
-    al6mn         Al6Mn         Al:math:`_6`Mn         10-20         0.5             10.5281/zenodo.20376067
+    al6mn         Al6Mn         Al6Mn                  10-20         0.5             10.5281/zenodo.20376067
     alpha_almnsi  Alpha-AlMnSi  :math:`\alpha`-AlMnSi  10-20         1.1             10.5281/zenodo.20376378
     ============  ============  =====================  ============  ==============  =======================
 
@@ -614,9 +643,7 @@ class Dataset:
         else:
             return
 
-    def fetch_file_path_from_collection(
-        self, downloader: pooch.HTTPDownloader
-    ) -> file_path:
+    def fetch_file_path_from_collection(self, downloader: pooch.HTTPDownloader) -> str:
         file_paths = marshall.fetch(
             "data/" + self.collection_name,
             downloader=downloader,

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -17,32 +17,27 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from functools import cache
+import hashlib
 import logging
 import os
 from pathlib import Path
 import shutil
+from typing import TYPE_CHECKING
 
 import hyperspy.api as hs
-import pooch
 
 from kikuchipy import __version__
+from kikuchipy._constants import verify_dependency_or_raise
 from kikuchipy.data._registry import registry_hashes, registry_urls
 from kikuchipy.io._io import load
 from kikuchipy.signals.ebsd import EBSD
 from kikuchipy.signals.ebsd_master_pattern import EBSDMasterPattern
 
-_logger = logging.getLogger(__name__)
+if TYPE_CHECKING:  # pragma: no cover
+    import pooch
 
-marshall = pooch.create(
-    path=pooch.os_cache("kikuchipy"),
-    base_url="",
-    version=__version__.replace(".dev", "+"),
-    version_dev="develop",
-    env="KIKUCHIPY_DATA_DIR",
-    registry=registry_hashes,
-    urls=registry_urls,
-    retry_if_failed=5,  # Five times at increasing intervals of 1 s
-)
+_logger = logging.getLogger(__name__)
 
 
 def _clear_directory(path: Path) -> None:
@@ -62,12 +57,35 @@ def clear_cache() -> None:
 
     This deletes all directories and files in the kikuchipy data cache
     directory, located at ``pooch.os_cache("kikuchipy")``.
+
+    Requires the optional :doc:`pooch <pooch:api/index>` package.
     """
+    verify_dependency_or_raise("pooch", "Clearing the cache")
+    import pooch
+
     cache_dir = Path(os.environ.get("KIKUCHIPY_DATA_DIR", pooch.os_cache("kikuchipy")))
     if cache_dir.exists():
         _clear_directory(cache_dir)
     else:
         _logger.debug("Data cache directory does not exist")
+
+
+@cache
+def get_fetching_pooch() -> "pooch.Pooch":
+    verify_dependency_or_raise("pooch", "Downloading data from external sources")
+
+    import pooch
+
+    return pooch.create(
+        path=pooch.os_cache("kikuchipy"),
+        base_url="",
+        version=__version__.replace(".dev", "+"),
+        version_dev="develop",
+        env="KIKUCHIPY_DATA_DIR",
+        registry=registry_hashes,
+        urls=registry_urls,
+        retry_if_failed=5,  # Five times at increasing intervals of 1 s
+    )
 
 
 # ----------------------- Experimental datasets ---------------------- #
@@ -571,7 +589,7 @@ def ebsd_master_pattern(
 class Dataset:
     file_relpath: Path
     file_package_path: Path
-    file_cache_path: Path
+    file_cache_path: Path | None
     expected_md5_hash: str = ""
     collection_name: str | None = None
 
@@ -586,7 +604,12 @@ class Dataset:
 
         file_relpath = "data" / file_relpath
         self.file_relpath = file_relpath
-        self.file_cache_path = Path(marshall.path) / self.file_relpath
+
+        try:
+            file_cache_path = Path(get_fetching_pooch().path) / self.file_relpath
+        except ImportError:
+            file_cache_path = None
+        self.file_cache_path = file_cache_path
 
         self.expected_md5_hash = registry_hashes[self.file_relpath_str]
 
@@ -606,27 +629,34 @@ class Dataset:
 
     @property
     def is_in_cache(self) -> bool:
-        return self.file_cache_path.exists()
+        return self.file_cache_path is not None and self.file_cache_path.exists()
 
     @property
     def file_directory(self) -> Path:
         return Path(os.path.join(*self.file_relpath.parts[1:-1]))
 
     @property
-    def file_path(self) -> Path:
+    def file_path(self) -> Path | None:
         if self.is_in_package:
             return self.file_package_path
         else:
             return self.file_cache_path
 
     @property
-    def file_path_str(self) -> str:
-        return self.file_path.as_posix()
+    def file_path_str(self) -> str | None:
+        if self.file_path is not None:
+            return self.file_path.as_posix()
+        else:
+            return
 
     @property
     def md5_hash(self) -> str | None:
-        if self.file_path.exists():
-            return pooch.file_hash(self.file_path_str, alg="md5")
+        if self.file_path is not None and self.file_path.exists():
+            h = hashlib.md5()
+            with open(self.file_path.as_posix(), "rb") as f:
+                for chunk in iter(lambda: f.read(65536), b""):
+                    h.update(chunk)
+            return h.hexdigest()
         else:
             return
 
@@ -643,14 +673,20 @@ class Dataset:
         else:
             return
 
-    def fetch_file_path_from_collection(self, downloader: pooch.HTTPDownloader) -> str:
+    def fetch_file_path_from_collection(
+        self, downloader: "pooch.HTTPDownloader"
+    ) -> str:
+        verify_dependency_or_raise("pooch", "Downloading data from external sources")
+        import pooch
+
+        marshall = get_fetching_pooch()
         file_paths = marshall.fetch(
-            "data/" + self.collection_name,
+            "data/" + str(self.collection_name),
             downloader=downloader,
             processor=pooch.Unzip(extract_dir=self.file_directory),
         )
 
-        os.remove(Path(marshall.path) / "data" / self.collection_name)
+        os.remove(Path(marshall.path) / "data" / str(self.collection_name))
 
         # Ensure the file is in the collection
         desired_name = self.file_relpath.name
@@ -670,16 +706,10 @@ class Dataset:
     def fetch_file_path(
         self, allow_download: bool = False, show_progressbar: bool | None = None
     ) -> str:
-        if show_progressbar is None:
-            show_progressbar = hs.preferences.General.show_progressbar
-        downloader = pooch.HTTPDownloader(
-            progressbar=show_progressbar, headers={"User-Agent": "agent"}
-        )
-
         if self.is_in_package:
             if self.has_correct_hash:
                 # Bypass pooch since the file is not in the cache
-                return self.file_path_str
+                return self.file_path.as_posix()
             else:
                 raise AttributeError(
                     f"File {self.file_path_str} has incorrect MD5 hash {self.md5_hash}"
@@ -687,7 +717,20 @@ class Dataset:
                     " is surprising. Please report it to the developers at "
                     "https://github.com/pyxem/kikuchipy/issues/new."
                 )
-        elif self.is_in_cache:
+
+        verify_dependency_or_raise("pooch", "Downloading data from external sources")
+        import pooch
+
+        marshall = get_fetching_pooch()
+
+        if show_progressbar is None:
+            show_progressbar = hs.preferences.General.show_progressbar
+
+        downloader = pooch.HTTPDownloader(
+            progressbar=show_progressbar, headers={"User-Agent": "agent"}
+        )
+
+        if self.is_in_cache:
             if self.has_correct_hash:
                 file_path = self.file_relpath_str
             elif allow_download:

--- a/src/kikuchipy/data/_data.py
+++ b/src/kikuchipy/data/_data.py
@@ -56,7 +56,8 @@ def clear_cache() -> None:
     """Clear the kikuchipy data cache directory.
 
     This deletes all directories and files in the kikuchipy data cache
-    directory, located at ``pooch.os_cache("kikuchipy")``.
+    directory, located at ``pooch.os_cache("kikuchipy")`` or the
+    environment variable ``KIKUCHIPY_DATA_DIR`` if set.
 
     .. note::
 
@@ -532,9 +533,8 @@ def ebsd_master_pattern(
     Parameters
     ----------
     phase
-        Name of available phase. Options are (see *Notes* for details):
-        ni, al, si, austenite, ferrite, steel_chi, steel_sigma,
-        steel_sigma2.
+        Name of available phase. Options are listed in the *phase*
+        column in the table in *Notes*.
     allow_download
         Whether to allow downloading the dataset from the internet to
         the local cache with the pooch Python package. Default is

--- a/src/kikuchipy/data/_registry.py
+++ b/src/kikuchipy/data/_registry.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2026 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 # All hashes are MD5 hashes and can be checked locally with e.g. md5sum.
 # All file paths are relative to the cache directory
@@ -69,6 +71,9 @@ _registry_hashes = {
     "ebsd_master_pattern/ferrite_mc_mp_20kv.h5":                    "md5:4b6c1456ed2d90e190c7a21c4c4c1aff",
     "ebsd_master_pattern/steel_sigma_mc_mp_20kv.h5":                "md5:2d965e399dbc13cb5983f29ceef6dfcd",
     "ebsd_master_pattern/steel_chi_mc_mp_20kv.h5":                  "md5:9e4dd974bf78a3f7d159575ff0d0a28a",
+    "ebsd_master_pattern/steel_sigma2_mc_mp_20kv.h5":               "md5:66c36d4bc0b7029038f59d1ab423c970",
+    "ebsd_master_pattern/r_mc_mp_20kv.h5":                          "md5:1a9dc668e4d27d13ab1d3cbdca5bcd84",
+    "ebsd_master_pattern/pi_mc_mp_20kv.h5":                         "md5:8e642ad0464e1396beed0f6f41d97f85",
 }
 # How to use permanent links to files on GitHub:
 # https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files
@@ -94,10 +99,13 @@ _registry_urls = {
     "ebsd_master_pattern/al_mc_mp_20kv.h5":             "https://zenodo.org/record/7628365/files/al_mc_mp_20kv.h5",
     "ebsd_master_pattern/ni_mc_mp_20kv.h5":             "https://zenodo.org/record/7498645/files/ni_mc_mp_20kv.h5",
     "ebsd_master_pattern/si_mc_mp_20kv.h5":             "https://zenodo.org/record/7498729/files/si_mc_mp_20kv.h5",
-    "ebsd_master_pattern/austenite_mc_mp_20kv.h5":  "https://zenodo.org/record/7628387/files/austenite_mc_mp_20kv.h5",
-    "ebsd_master_pattern/ferrite_mc_mp_20kv.h5":    "https://zenodo.org/record/7628394/files/ferrite_mc_mp_20kv.h5",
+    "ebsd_master_pattern/austenite_mc_mp_20kv.h5":      "https://zenodo.org/record/7628387/files/austenite_mc_mp_20kv.h5",
+    "ebsd_master_pattern/ferrite_mc_mp_20kv.h5":        "https://zenodo.org/record/7628394/files/ferrite_mc_mp_20kv.h5",
     "ebsd_master_pattern/steel_chi_mc_mp_20kv.h5":      "https://zenodo.org/record/7628417/files/steel_chi_mc_mp_20kv.h5",
     "ebsd_master_pattern/steel_sigma_mc_mp_20kv.h5":    "https://zenodo.org/record/7628443/files/steel_sigma_mc_mp_20kv.h5",
+    "ebsd_master_pattern/steel_sigma2_mc_mp_20kv.h5":   "https://zenodo.org/records/20376903/files/steel_sigma2_mc_mp_20kv.h5",
+    "ebsd_master_pattern/r_mc_mp_20kv.h5":              "https://zenodo.org/records/20376828/files/r_mc_mp_20kv.h5",
+    "ebsd_master_pattern/pi_mc_mp_20kv.h5":             "https://zenodo.org/records/20376759/files/pi_mc_mp_20kv.h5",
 }
 # fmt: on
 

--- a/src/kikuchipy/data/_registry.py
+++ b/src/kikuchipy/data/_registry.py
@@ -74,6 +74,9 @@ _registry_hashes = {
     "ebsd_master_pattern/steel_sigma2_mc_mp_20kv.h5":               "md5:66c36d4bc0b7029038f59d1ab423c970",
     "ebsd_master_pattern/r_mc_mp_20kv.h5":                          "md5:1a9dc668e4d27d13ab1d3cbdca5bcd84",
     "ebsd_master_pattern/pi_mc_mp_20kv.h5":                         "md5:8e642ad0464e1396beed0f6f41d97f85",
+    "ebsd_master_pattern/cr2n_mc_mp_20kv.h5":                       "md5:b0b03f41cc1ae3fa0b2f2bf69d494417",
+    "ebsd_master_pattern/al6mn_mc_mp_20kv.h5":                      "md5:a00f332a77d60be48584df779da5aa1f",
+    "ebsd_master_pattern/alpha_almnsi_mc_mp_20kv.h5":               "md5:92d18a632b539d7a4548ba99aa94d7f1",
 }
 # How to use permanent links to files on GitHub:
 # https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files
@@ -106,6 +109,9 @@ _registry_urls = {
     "ebsd_master_pattern/steel_sigma2_mc_mp_20kv.h5":   "https://zenodo.org/records/20376903/files/steel_sigma2_mc_mp_20kv.h5",
     "ebsd_master_pattern/r_mc_mp_20kv.h5":              "https://zenodo.org/records/20376828/files/r_mc_mp_20kv.h5",
     "ebsd_master_pattern/pi_mc_mp_20kv.h5":             "https://zenodo.org/records/20376759/files/pi_mc_mp_20kv.h5",
+    "ebsd_master_pattern/cr2n_mc_mp_20kv.h5":           "https://zenodo.org/records/20376534/files/cr2n_mc_mp_20kv.h5",
+    "ebsd_master_pattern/al6mn_mc_mp_20kv.h5":          "https://zenodo.org/records/20376068/files/al6mn_mc_mp_20kv.h5",
+    "ebsd_master_pattern/alpha_almnsi_mc_mp_20kv.h5":   "https://zenodo.org/records/20376379/files/alpha_almnsi_mc_mp_20kv.h5",
 }
 # fmt: on
 

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -277,3 +277,11 @@ class TestData:
         to check dataset availability.
         """
         assert marshall.is_available(f"data/{dataset}")
+
+    def test_clear_cache(self, tmp_path, monkeypatch, capsys):
+        dummy_file = tmp_path / "dummy_file"
+        dummy_file.touch()
+        monkeypatch.setenv("KIKUCHIPY_DATA_DIR", str(tmp_path))
+        kp.data.clear_cache()
+        captured = capsys.readouterr()
+        assert "dummy_file" in captured.out

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -267,6 +267,9 @@ class TestData:
             "ebsd_master_pattern/steel_sigma2_mc_mp_20kv.h5",
             "ebsd_master_pattern/r_mc_mp_20kv.h5",
             "ebsd_master_pattern/pi_mc_mp_20kv.h5",
+            "ebsd_master_pattern/cr2n_mc_mp_20kv.h5",
+            "ebsd_master_pattern/al6mn_mc_mp_20kv.h5",
+            "ebsd_master_pattern/alpha_almnsi_mc_mp_20kv.h5",
         ],
     )
     def test_dataset_availability(self, dataset):

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -284,5 +284,6 @@ class TestData:
         dummy_file.touch()
         monkeypatch.setenv("KIKUCHIPY_DATA_DIR", str(tmp_path))
         kp.data.clear_cache()
+        assert not dummy_file.exists()
         captured = capsys.readouterr()
         assert "dummy_file" in captured.out

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -264,6 +264,9 @@ class TestData:
             "ebsd_master_pattern/ferrite_mc_mp_20kv.h5",
             "ebsd_master_pattern/steel_chi_mc_mp_20kv.h5",
             "ebsd_master_pattern/steel_sigma_mc_mp_20kv.h5",
+            "ebsd_master_pattern/steel_sigma2_mc_mp_20kv.h5",
+            "ebsd_master_pattern/r_mc_mp_20kv.h5",
+            "ebsd_master_pattern/pi_mc_mp_20kv.h5",
         ],
     )
     def test_dataset_availability(self, dataset):

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 
 import kikuchipy as kp
-from kikuchipy.data._data import Dataset, marshall
+from kikuchipy.data._data import Dataset, get_fetching_pooch
 
 
 class TestData:
@@ -276,6 +276,7 @@ class TestData:
         """Ping registry URLs of remote repositories (GitHub and Zenodo)
         to check dataset availability.
         """
+        marshall = get_fetching_pooch()
         assert marshall.is_available(f"data/{dataset}")
 
     def test_clear_cache(self, tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR improves the data module by:
- Adding more master patterns from Zenodo:
  - Alternative sigma phase (found in super duplex stainless steel, SDSS): https://zenodo.org/records/20376903
  - Cr2N (found in SDSS): https://zenodo.org/records/20376534
  - R, Fe-Cr-Mo (found in SDSS): https://zenodo.org/records/20376828
  - Pi, Fe-Mo (found in SDSS): https://zenodo.org/records/20376759
  - Al6Mn (secondary phase in Al-Mn alloys): https://zenodo.org/records/20376068
  - alpha-AlMnSi (secondary phase in Al alloys): https://zenodo.org/records/20376379
- Function to clear cached kikuchipy data
- Make Pooch an optional dependency (removed from `pip install kikuchipy` and `conda install -c conda-forge kikuchipy-base`)

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)
- [x] Clear data function
- [x] Make Pooch optional dependency

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> mp_r = kp.data.ebsd_master_pattern("steel_r", allow_download=True)
>>> mp_sigma2 = kp.data.ebsd_master_pattern("steel_sigma2", allow_download=True)
>>> mp_pi = kp.data.ebsd_master_pattern("steel_pi", allow_download=True)
>>> mp_cr2n = kp.data.ebsd_master_pattern("steel_cr2n", allow_download=True)
>>> mp_al6mn = kp.data.ebsd_master_pattern("al6mn", allow_download=True)
>>> mp_almnsi = kp.data.ebsd_master_pattern("alpha_almnsi", allow_download=True)
>>> kp.data.clear_cache()
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
