### PR TITLE
Fix detector to sample properties

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,9 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.14"
             LABEL: -minimum_requirement
+          - os: ubuntu-latest
+            python-version: "3.14"
+            LABEL: -build-install-wheel
     steps:
       - uses: actions/checkout@v6
 
@@ -58,13 +61,27 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies and package
+      - name: Install dependencies
         shell: bash
         run: |
           pip install wheel
-          pip install -U -e ".[tests,coverage]"
+          pip install -U ".[tests,coverage]"
 
-      - name: Install oldest supported version
+      - name: Install package in editable mode
+        if: ${{ contains(matrix.LABEL, 'build-install-wheel') == false }}
+        shell: bash
+        run: |
+          pip install -U -e .
+
+      - name: Install package from built wheel
+        if: contains(matrix.LABEL, 'build-install-wheel')
+        shell: bash
+        run: |
+          pip install build
+          python -m build
+          python -m pip install dist/kikuchipy-*-any.whl
+
+      - name: Install oldest supported versions of dependencies
         if: contains(matrix.LABEL, 'oldest')
         run: |
           pip install ${{ matrix.DEPENDENCIES }}
@@ -73,14 +90,13 @@ jobs:
         if: ${{ contains(matrix.LABEL, 'minimum_requirement') == false && matrix.os != 'macos-latest' }}
         shell: bash
         run: |
-          pip install -e ".[all]"
+          pip install ".[all]"
           pip install pyopencl
 
       - name: Install optional dependencies on macOS (without nlopt)
         if: ${{ contains(matrix.LABEL, 'minimum_requirement') == false && matrix.os == 'macos-latest' }}
         shell: bash
         run: |
-          pip install -e .
           pip install "pyebsdindex[gpu]" pyvista
 
       - name: Display Python, pip and package versions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Fixed
   in the correct sense, i.e. represent vectors in the sample reference frame in the
   detector reference frame: ``v_d = R_s2d * v_s``.
   (`#797 <https://github.com/pyxem/kikuchipy/pull/797>`_)
+- Disallow PyEBSDIndex 0.3.10 due to bug in gnomonic correction for EMsoft PC.
+  (`#797 <https://github.com/pyxem/kikuchipy/pull/797>`_)
 
 
 0.12.0 (2026-05-24)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,16 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
+0.12.1 (2026-05-30)
+===================
+
+Fixed
+-----
+- Invert the rotation ``EBSDDetector.sample_to_detector`` so that it transforms vectors
+  in the correct sense, i.e. represent vectors in the sample reference frame in the
+  detector reference frame: ``v_d = R_s2d * v_s``.
+  (`#797 <https://github.com/pyxem/kikuchipy/pull/797>`_)
+
 
 0.12.0 (2026-05-24)
 ===================

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you are using kikuchipy in your research, please help our scientific visibility by citing our work!"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Ånes"
+    given-names: "Håkon W."
+    orcid: "0000-0002-1213-2911"
+  - family-names: "Crout"
+    given-names: "Phillip"
+    orcid: "0000-0001-5754-0938"
+  - family-names: "Lervik"
+    given-names: "Lars Andreas"
+  - family-names: "Natlandsmyr"
+    given-names: "Ole"
+  - family-names: "Bergh"
+    given-names: "Tina"
+    orcid: "0000-0003-3757-3876"
+  - family-names: "Hjelen"
+    given-names: "Jarle"
+  - family-names: "van Helvoort"
+    given-names: "Antonius T. J."
+    orcid: "0000-0001-6437-1474"
+  - family-names: "Marthinsen"
+    given-names: "Knut"
+    orcid: "0000-0003-1732-6421"
+  doi: 10.48550/arXiv.2605.25722
+  title: "kikuchipy: an open-source toolbox for analysis of EBSD patterns"
+  journal: "arXiv preprint arXiv:2605.25722"
+  year: 2026
+  eprint: "2605.25722"
+  archive-prefix: "arXiv"
+  primary-class: "cond-mat.mtrl-sci"
+  url: "https://arxiv.org/abs/2605.25722"

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,10 @@ library.
 .. |conda_downloads| image:: https://img.shields.io/conda/dn/conda-forge/kikuchipy.svg?label=conda%20downloads
    :target: https://anaconda.org/conda-forge/kikuchipy
 
-.. |doi| image:: https://zenodo.org/badge/doi/10.5281/zenodo.3597646.svg
+.. |arxiv_doi| image:: https://img.shields.io/badge/DOI-10.48550/arXiv.2605.25722-blue
+   :target: https://doi.org/10.48550/arXiv.2605.25722
+
+.. |zenodo_doi| image:: https://zenodo.org/badge/doi/10.5281/zenodo.3597646.svg
    :target: https://doi.org/10.5281/zenodo.3597646
 
 .. |GPLv3| image:: https://img.shields.io/github/license/pyxem/kikuchipy
@@ -58,7 +61,7 @@ library.
 +----------------------+------------------------------------------------+
 | Activity             | |pypi_downloads| |conda_downloads|             |
 +----------------------+------------------------------------------------+
-| Citation             | |doi|                                          |
+| Citation             | |arxiv_doi| |zenodo_doi|                       |
 +----------------------+------------------------------------------------+
 | License              | |GPLv3|                                        |
 +----------------------+------------------------------------------------+
@@ -95,5 +98,8 @@ Further details are available in the
 Citing kikuchipy
 ----------------
 
-If you are using kikuchipy in your scientific research, please help our scientific
-visibility by citing the `Zenodo DOI <https://doi.org/10.5281/zenodo.3597646>`__.
+If you are using kikuchipy in your research, please help our scientific visibility by
+citing our work!
+
+- Pre-print: https://doi.org/10.48550/arXiv.2605.25722
+- Software: https://doi.org/10.5281/zenodo.3597646

--- a/conftest.py
+++ b/conftest.py
@@ -106,6 +106,9 @@ def skipif_no_vtk_support():
 
 def pytest_sessionstart(session):
     _ = kp.data.nickel_ebsd_large(allow_download=True)
+    _ = kp.data.si_ebsd_moving_screen(0, allow_download=True)
+    _ = kp.data.si_ebsd_moving_screen(5, allow_download=True)
+    _ = kp.data.si_ebsd_moving_screen(10, allow_download=True)
     plt.rcParams.update({"backend": "agg", "figure.max_open_warning": False})
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -79,7 +79,9 @@ def pytest_runtest_setup(item):
     # https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_runtest_setup
     for marker in MARKERS:
         marker_str = f"--{marker}"
-        if marker in item.keywords and not item.config.getoption(marker_str):
+        if marker in item.keywords and not item.config.getoption(
+            marker_str, default=False
+        ):
             pytest.skip(f"Needs {marker_str} flag to run")
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -84,5 +84,8 @@ Learning resources
 Citing kikuchipy
 ================
 
-If you are using kikuchipy in your scientific research, please help our scientific
-visibility by citing the Zenodo DOI: https://doi.org/10.5281/zenodo.3597646.
+If you are using kikuchipy in your research, please help our scientific visibility by
+citing our work!
+
+- Pre-print: https://doi.org/10.48550/arXiv.2605.25722
+- Software: https://doi.org/10.5281/zenodo.3597646

--- a/doc/user/applications.rst
+++ b/doc/user/applications.rst
@@ -12,8 +12,41 @@ If you think your work should be listed here, please raise an issue `on GitHub
 Most of these works are also listed when searching for ``"kikuchipy"`` `on Google Scholar
 <https://scholar.google.com/scholar?hl=no&as_sdt=0%2C5&q=%22kikuchipy%22&btnG=>`__.
 
+2026
+====
+
+- H W. Ånes, P. Crout, L. A. Lervik, O. Natlandsmyr, T. Bergh, J. Hjelen,
+  A. T. J. van Helvoort and K. Marthinsen, "kikuchipy: an open-source toolbox for
+  analysis of EBSD patterns," arXiv preprint (2026).
+  https://doi.org/10.48550/arXiv.2605.25722.
+- L. Kokosza, J. Pawlak, M. Marciszko-Wiąckowska, G. Cios, P. Jabłoński, A. Naumov,
+  M. Przybylski and Z. Mitura, "The growth and structural characterization of a
+  La0.67Sr0.33MnO3/BaTiO3 superstructure (superlattice)," *Foundations of
+  Crystallography* **82** (2026).
+  https://doi.org/10.1107/S205327332600313X.
+
+
+2024
+====
+
+- Z. Xu, H. W. Ånes, S. Gorelick, X. Fang and P. Miller, "OpenECCI-A Streamlined
+  Open-Source Workflow for Electron Channelling Contrast Imaging of Crystal Defects,"
+  *In BIO Web of Conferences* **129** (2024).
+  https://doi.org/10.1051/bioconf/202412907004.
+- Z. Mitura, G. Szwachta, L. Kokosza and M. Przybylski, "Identification of Kikuchi lines
+  in electron diffraction patterns collected in small-angle geometry," *Foundations of
+  Crystallography* **80** (2024).
+  https://doi.org/10.1107/S2053273323009385.
+- A. Celotto, L. Sandnes, Ø. Grong, J. A. Sørhaug, G. Stefani, D. Wan, P. E. Vullum, R.
+  Holmestad and F. Berto, "Cold butt welding of dissimilar aluminum alloys:
+  Characterization and interface bonding conditions," *Materials Science and
+  Engineering: A* **897** (2024).
+  https://doi.org/10.1016/j.msea.2024.146279.
+
+
 2023
 ====
+
 - A. V. Bugten, L. Michels, R. B. Brurok, C. Hartung, E. Ott, L. Vines, Y. Li,
   L. Arnberg and M. Di Sabatino, "The Role of Boron in Low Copper Spheroidal Graphite
   Irons," *Metallurgical and Materials Transactions A* **54** (2023).
@@ -30,11 +63,13 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
   (`arXiv <https://doi.org/10.48550/arxiv.2212.03527>`__).
 - T. Bergh, H. W. Ånes, R. Aune, S. Wenner, R. Holmestad, X. Ren and P. E. Vullum,
   "Intermetallic Phase Layers in Cold Metal Transfer Aluminium-Steel Welds with an
-  Al-Si–Mn Filler Alloy," *Materials Transactions* **64(2)** (2023).
+  Al-Si-Mn Filler Alloy," *Materials Transactions* **64(2)** (2023).
   https://doi.org/10.2320/matertrans.MT-LA2022046.
+
 
 2022
 ====
+
 - O. M. Akselsen, R. Bjørge, H. W. Ånes, X. Ren, and B. Nyhus, "Microstructure and
   Properties of Wire Arc Additive Manufacturing of Inconel 625," *Metals* **12(11)**
   (2022).
@@ -50,6 +85,7 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
   https://doi.org/10.1002/adma.202203449
   (`arXiv <https://doi.org/10.48550/arxiv.2204.07979>`__).
 
+
 2021
 ====
 
@@ -57,6 +93,7 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
   Wire Arc Additive Manufacturing of Superduplex Stainless Steel," *Metals* **11(12)**
   (2021).
   https://doi.org/10.3390/met11122045.
+
 
 2020
 ====

--- a/examples/reference_frames/rotate_vectors_from_sample_to_detector.py
+++ b/examples/reference_frames/rotate_vectors_from_sample_to_detector.py
@@ -1,0 +1,100 @@
+#
+# Copyright 2019-2026 the kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Rotate vectors from sample to detector reference frame
+======================================================
+
+This example shows how to transform column vectors given in the sample reference frame
+to the detector reference frame using
+:class:`~kikuchipy.detectors.EBSDDetector.sample_to_detector`.
+"""
+
+# %%
+# Imports.
+import numpy as np
+import orix.vector as ove
+
+import kikuchipy as kp
+
+# %%
+# Create a detector.
+det = kp.detectors.EBSDDetector()
+print(det)
+
+# %%
+# Get rotation and orientation matrix.
+R_s2d = det.sample_to_detector
+om_s2d = R_s2d.to_matrix().squeeze()
+
+print(R_s2d)
+print(om_s2d.round(4))
+
+# %%
+# We see that the detector :math:`X_d` is parallel to the sample :math:`Y_s`.
+# If we change the detector :attr:`~kikuchipy.detectors.EBSDDetector.azimuthal` angle,
+# this would not be the case.
+# We can check the effect of various other angles easily.
+print(
+    kp.detectors.EBSDDetector(azimuthal=5)
+    .sample_to_detector.to_matrix()
+    .squeeze()
+    .round(4)
+)
+
+# %%
+# Create some vectors given in the sample reference frame.
+v_s = ove.Vector3d.random(4)
+print(v_s)
+
+# %%
+# Rotate to the detector using two paths:
+# * Use the returned :class:`~orix.quaternion.Rotation` directly
+# * Via NumPy's matrix multiplication sign '@' (making sure to transpose the underlying
+#   vectors data to make the column vectors)
+# * Via NumPy's :func:`~numpy.dot` function (making sure to transpose the underlying
+#   vectors data to make the column vectors)
+v_d = R_s2d * v_s
+v_d_np1 = (om_s2d @ v_s.data.T).T
+v_d_np2 = np.dot(om_s2d, v_s.data.T).T
+
+print(v_d.data.round(4))
+print(v_d_np1.round(4))
+print(v_d_np2.round(4))
+
+# Check equality
+print(np.allclose(v_d.data, v_d_np1, atol=1e-4))
+print(np.allclose(v_d.data, v_d_np2, atol=1e-4))
+
+# %%
+# Rotate from the detector to the sample.
+R_d2s = ~R_s2d
+om_d2s = om_s2d.T
+
+v_s2 = R_d2s * v_d
+v_s2_np1 = (om_d2s @ v_d.data.T).T
+v_s2_np2 = np.dot(om_d2s, v_d.data.T).T
+
+print(v_s2.data.round(4))
+print(v_s2_np1.round(4))
+print(v_s2_np2.round(4))
+
+# Check equality
+print(np.allclose(v_s2.data, v_s2_np1, atol=1e-4))
+print(np.allclose(v_s2.data, v_s2_np2, atol=1e-4))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ all = [
     "IPython",
     "nlopt",
     "psygnal",
-    "pyebsdindex >= 0.3.9.2",
+    # Restriction due to https://github.com/USNavalResearchLaboratory/PyEBSDIndex/issues/80
+    "pyebsdindex >= 0.3.9.2, != 0.3.10",
     "pyvista",
 ]
 doc = [
@@ -83,7 +84,7 @@ doc = [
     "numpydoc != 1.9.0",
     "nlopt",
     "pydata-sphinx-theme",
-    "pyebsdindex                  ~= 0.2",
+    "pyebsdindex                  >= 0.3.9.2, != 0.3.10",
     "pyvista",
     "sphinx                       >= 3.0.2",
     "sphinx-codeautolink[ipython] <  0.14",

--- a/src/kikuchipy/__init__.py
+++ b/src/kikuchipy/__init__.py
@@ -36,7 +36,7 @@ credits = [
     "Tijmen Vermeij",
 ]
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 

--- a/src/kikuchipy/detectors/_ebsd_detector.py
+++ b/src/kikuchipy/detectors/_ebsd_detector.py
@@ -97,11 +97,16 @@ PC_CONVENTIONS_ALIASES: dict[PC_CONVENTIONS_SINGLE, list[PC_CONVENTIONS]] = {
     fastmath=True,
     nogil=True,
 )
-def _detector_to_sample_intrinsic_matrix(
+def _sample_to_detector_matrix(
     sigma: float, theta: float, omega: float, gamma: float
 ) -> np.ndarray:
-    """Return detector axes in sample frame from intrinsic rotations."""
-    # Rows are detector (X_d, Y_d, Z_d) in sample coordinates.
+    """Return the passive sample-to-detector rotation matrix.
+
+    Rows of the returned matrix are the detector basis vectors
+    (X_d, Y_d, Z_d) expressed in sample-frame coordinates, so that
+    ``M @ v_sample = v_det`` for column vectors.
+    """
+    # Rows are detector (X_d, Y_d, Z_d) in sample coordinates
     basis = np.array(
         [
             [0, 1, 0],
@@ -829,29 +834,15 @@ class EBSDDetector:
 
     @property
     def sample_to_detector(self) -> oqu.Rotation:
-        """Return a rotation that transforms vectors in the sample
-        reference frame to the detector reference frame.
-
-        Examples
-        --------
-        Get both transformations as rotations and orientation matrices
-
-        >>> import kikuchipy as kp
-        >>> det = kp.detectors.EBSDDetector()
-        >>> R_s2d = det.sample_to_detector
-        >>> om_s2d = R_s2d.to_matrix().squeeze()
-        >>> R_d2s = ~R_s2d
-        >>> om_d2s = om_s2d.T
+        """Return a rotation that transform vectors given in the sample
+        reference frame in the detector reference frame.
         """
         sigma = np.deg2rad(self.sample_tilt)
         theta = np.deg2rad(self.tilt)
         omega = np.deg2rad(self.azimuthal)
         gamma = np.deg2rad(self.twist)
-        detector_to_sample = _detector_to_sample_intrinsic_matrix(
-            sigma, theta, omega, gamma
-        )
-        sample_to_detector = oqu.Rotation.from_matrix(detector_to_sample.T)
-        return sample_to_detector
+        m = _sample_to_detector_matrix(sigma, theta, omega, gamma)
+        return oqu.Rotation.from_matrix(m)
 
     @property
     def _average_gnomonic_bounds(self) -> np.ndarray:

--- a/src/kikuchipy/indexing/_refinement/_refinement.py
+++ b/src/kikuchipy/indexing/_refinement/_refinement.py
@@ -339,7 +339,7 @@ def _get_crystal_map_parameters(
 
 def _refine_orientation(
     xmap: CrystalMap,
-    detector,
+    detector: "EBSDDetector",
     master_pattern,
     energy: int | float,
     patterns: np.ndarray | da.Array,

--- a/src/kikuchipy/indexing/_refinement/_solvers.py
+++ b/src/kikuchipy/indexing/_refinement/_solvers.py
@@ -98,54 +98,52 @@ def _refine_orientation_solver_scipy(
 ):
     """Maximize the similarity between an experimental pattern and a
     projected simulated pattern by optimizing the orientation
-    (Rodrigues-Frank vector) used in the projection.
+    (Euler) used in the projection.
 
     Parameters
     ----------
     pattern
         Flattened experimental pattern.
     rotation
-        Rodrigues-Frank vector components (Rx, Ry, Rz), unscaled.
+        Euler components (phi1, Phi, phi2), unscaled.
     signal_mask
         Boolean mask equal to the experimental patterns' detector shape
-        ``(n rows, n columns)``, where only pixels equal to ``False``
-        are matched.
+        (n rows, n columns), where only pixels equal to False are
+        matched.
     rescale
         Whether pattern intensities must be rescaled to [-1, 1] and the
         data type set to 32-bit floats.
     method
-        A supported :mod:`scipy.optimize` function. See ``method``
+        A supported :mod:`scipy.optimize` function. See *method*
         parameter in :meth:`kikuchipy.signals.EBSD.refine_orientation`.
     method_kwargs
-        Keyword arguments passed to the ``method`` function. For the
-        list of possible arguments, see the SciPy documentation.
+        Keyword arguments passed to the *method* function. For the list
+        of possible arguments, see the SciPy documentation.
     fixed_parameters
         Fixed parameters used in the projection.
     direction_cosines
         Vector array of shape (n pixels, 3) and data type 32-bit floats.
-        If not given, ``pcx``, ``pcy``, ``pcz``, ``nrows``, ``ncols``,
-        ``tilt``, ``azimuthal``, and ``sample_tilt`` must be passed.
+        If not given, *pcx*, *pcy*, *pcz*, *nrows*, *ncols*, *tilt*,
+        *azimuthal*, and *sample_tilt* must be passed.
     pcx
         Projection center (PC) x coordinate. Must be passed if
-        ``direction_cosines`` is not given.
+        *direction_cosines* is not given.
     pcy
-        PC y coordinate. Must be passed if ``direction_cosines`` is not
+        PC y coordinate. Must be passed if *direction_cosines* is not
         given.
     pcz
-        PC z coordinate. Must be passed if ``direction_cosines`` is not
+        PC z coordinate. Must be passed if *direction_cosines* is not
         given.
     nrows
-        Number of detector rows. Must be passed if ``direction_cosines``
+        Number of detector rows. Must be passed if *direction_cosines*
         is not given.
     ncols
         Number of detector columns. Must be passed if
-        ``direction_cosines`` is not given.
+        *direction_cosines* is not given.
     om_detector_to_sample
-        Orientation matrix used for transforming from the detector
-        reference frame to the sample reference frame. This is the
-        inverse of EBSDDetector.sample_to_detector expressed as a
-        3x3 numpy array rather than an orix Rotation. Must be passed
-        if ``direction_cosines`` is not given.
+        Orientation matrix for transforming from the detector reference
+        frame to the sample reference frame. Must be passed if
+        *direction_cosines* is not given.
     n_pseudo_symmetry_ops
         Number of pseudo-symmetry operators. Default is 0.
 
@@ -155,8 +153,12 @@ def _refine_orientation_solver_scipy(
         Highest normalized cross-correlation score.
     num_evals
         Number of optimization evaluations.
-    phi1, Phi, phi2
-        Optimized orientation (Euler angles) in radians.
+    phi1
+        First optimized Euler angle from *rotation* in radians.
+    Phi
+        Second optimized Euler angle from *rotation* in radians.
+    phi2
+        Third optimized Euler angle from *rotation* in radians.
     """
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 

--- a/src/kikuchipy/signals/util/_master_pattern.py
+++ b/src/kikuchipy/signals/util/_master_pattern.py
@@ -100,11 +100,11 @@ def _get_direction_cosines_from_detector(
         Flattened direction cosines.
     """
     if detector.navigation_shape == (1,):
-        pcx, pcy, pcz = detector.pc.squeeze().astype(np.float64)
+        pcz = np.float64(detector.pcz.squeeze())
         gnomonic_bounds = detector.gnomonic_bounds.squeeze().astype(np.float64)
         func = _get_direction_cosines_for_fixed_pc
     else:
-        pcx, pcy, pcz = detector.pc_flattened.T.astype(np.float64)
+        pcz = detector.pcz.ravel().astype(np.float64)
         gnomonic_bounds = detector.gnomonic_bounds.reshape((-1, 4)).astype(np.float64)
         func = _get_direction_cosines_for_varying_pc
 
@@ -140,8 +140,6 @@ def _get_direction_cosines_for_fixed_pc(
 ) -> np.ndarray:
     """Return direction cosines for a single projection center (PC).
 
-    Algorithm adapted from that used in :cite:`britton2016tutorial`.
-
     Parameters
     ----------
     gnomonic_bounds
@@ -153,13 +151,10 @@ def _get_direction_cosines_for_fixed_pc(
     ncols
         Number of detector columns.
     om_detector_to_sample
-        The orientation matrix which transforms
-        vectors in the detector reference frame, CSd,
-        to the sample reference frame, CSs. This is
-        the inverse rotation of the
-        EBSDDetector.sample_to_detector property.
+        Orientation matrix that transforms vectors in the detector
+        reference frame, CSd, to the sample reference frame, CSs.
     signal_mask
-        1D signal mask with ``True`` values for pixels to get direction
+        1D signal mask with True values for pixels to get direction
         cosines for.
 
     Returns
@@ -168,17 +163,13 @@ def _get_direction_cosines_for_fixed_pc(
         Direction cosines for detector pixels in the mask of shape
         (n_pixels, 3) and data type of 64-bit floats.
 
-    See Also
-    --------
-    kikuchipy.detectors.EBSDDetector
-
     Notes
     -----
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
 
-    A previous version of this algorithm was adapted from EMsoft,
-    see :cite:`callahan2013dynamical`.
+    A previous version of this algorithm was adapted from EMsoft, see
+    :cite:`callahan2013dynamical`.
     """
     x_scale = (gnomonic_bounds[1] - gnomonic_bounds[0]) / ncols
     y_scale = (gnomonic_bounds[3] - gnomonic_bounds[2]) / nrows
@@ -202,7 +193,8 @@ def _get_direction_cosines_for_fixed_pc(
         r_g_array[i, 1] = (det_gn_y[rows[i]] - y_half_step) * pcz
         r_g_array[i, 2] = pcz
 
-    r_g_array = np.dot(r_g_array, om_detector_to_sample)
+    # Transpose orientation matrix to multiply row vectors
+    r_g_array = np.dot(r_g_array, om_detector_to_sample.T)
 
     # Normalize
     norm = np.sqrt(np.sum(np.square(r_g_array), axis=-1))
@@ -232,8 +224,6 @@ def _get_direction_cosines_for_varying_pc(
     """Return sets of direction cosines for varying projection centers
     (PCs).
 
-    Algorithm adapted from that used in :cite:`britton2016tutorial`.
-
     Parameters
     ----------
     gnomonic_bounds
@@ -246,24 +236,18 @@ def _get_direction_cosines_for_varying_pc(
     ncols
         Number of detector columns.
     om_detector_to_sample
-        The orientation matrix which transforms
-        vectors in the detector reference frame, CSd, to the
-        sample reference frame, CSs. One matrix valid for
-        ALL PCs. This is the inverse rotation of the
-        EBSDDetector.sample_to_detector property.
+        The orientation matrix which transforms column vectors in the
+        detector reference frame, CSd, to the sample reference frame,
+        CSs. One matrix valid for ALL PCs.
     signal_mask
-        1D signal mask with ``True`` values for pixels to get direction
+        1D signal mask with True values for pixels to get direction
         cosines for.
 
     Returns
     -------
     r_g_array
         Direction cosines for each detector pixel for each PC, of shape
-        (n PCs, n_pixels, 3) and data type of 64-bit floats.
-
-    See Also
-    --------
-    kikuchipy.detectors.EBSDDetector
+        (n PCs, n pixels, 3) and data type of 64-bit floats.
 
     Notes
     -----
@@ -277,6 +261,9 @@ def _get_direction_cosines_for_varying_pc(
     n_pcs = pcz.size
     n_pixels = idx_1d.size
     r_g_array = np.zeros((n_pcs, n_pixels, 3), dtype=np.float64)
+
+    # Transpose orientation matrix to multiple row vectors
+    om_detector_to_sample_row = om_detector_to_sample.T
 
     for i in nb.prange(n_pcs):
         x_scale = (gnomonic_bounds[i, 1] - gnomonic_bounds[i, 0]) / ncols
@@ -296,7 +283,7 @@ def _get_direction_cosines_for_varying_pc(
             r_g_a[j, 1] = (det_gn_y[rows[j]] - y_half_step) * pcz[i]
             r_g_a[j, 2] = pcz[i]
 
-        r_g_a = np.dot(r_g_a, om_detector_to_sample)
+        r_g_a = np.dot(r_g_a, om_detector_to_sample_row)
 
         r_g_array[i] = r_g_a
 

--- a/src/kikuchipy/simulations/_geometrical_simulation.py
+++ b/src/kikuchipy/simulations/_geometrical_simulation.py
@@ -58,7 +58,7 @@ def _bands_and_zone_axes_kernel(
     nb_bands = 0
     nb_za = 0
 
-    # Bands
+    # {hkl} row vectors from reciprocal lattice -> detector
     for i in range(n_hkl):
         v_h = hkl[i, 0]
         v_k = hkl[i, 1]
@@ -84,7 +84,7 @@ def _bands_and_zone_axes_kernel(
         band_buf[nb_bands, 3] = max_r * np.sin(a2)
         nb_bands += 1
 
-    # Zone axes
+    # <uvw> row vectors from direct lattice -> detector
     for i in range(n_uvw):
         u0 = uvw[i, 0]
         u1 = uvw[i, 1]
@@ -103,69 +103,6 @@ def _bands_and_zone_axes_kernel(
         nb_za += 1
 
     return band_buf[:nb_bands], za_buf[:nb_za]
-
-
-def _get_geometrical_bands_and_zone_axes_gnomonic(
-    hkl: np.ndarray,
-    uvw: np.ndarray,
-    base: np.ndarray,
-    recbase: np.ndarray,
-    rotation_matrix: np.ndarray,
-    u_s: np.ndarray,
-    max_r_gnomonic: float = 10.0,
-) -> tuple[np.ndarray, np.ndarray]:
-    r"""Return gnomonic coordinates of visible Kikuchi bands
-    :math:`{hkl}` and zone axes :math:`\left<uvw\right>` for a single
-    crystal orientation.
-
-    Parameters
-    ----------
-    hkl
-        Miller indices of the reflectors, shape (n, 3).
-    uvw
-        Zone axis indices, shape (m, 3). These should be obtained from
-        the cross products of *hkl*.
-    base
-        Direct lattice basis (3, 3), from
-        ``phase.structure.lattice.base``.
-    recbase
-        Reciprocal lattice basis (3, 3), from
-        ``phase.structure.lattice.recbase``.
-    rotation_matrix
-        Crystal orientation rotation matrix (3, 3), from
-        ``rotation.to_matrix().squeeze()``.
-    u_s
-        Detector-to-sample rotation matrix (3, 3), from
-        ``(~detector.sample_to_detector).to_matrix().squeeze()``.
-    max_r_gnomonic
-        Maximum gnomonic radius. Default is 10.0.
-
-    Returns
-    -------
-    band_coords
-        Gnomonic plane-trace endpoints (x0, y0, x1, y1) of visible
-        Kikuchi bands, shape (k, 4).
-    zone_axes_coords
-        Gnomonic (x, y) positions of visible zone axes, shape (l, 2).
-    """
-    u_os = rotation_matrix @ u_s
-
-    # Reciprocal lattice -> crystal -> sample -> detector
-    u_kstar = recbase.T @ u_os
-
-    # Direct lattice -> crystal -> sample -> detector
-    u_k = base @ u_os
-
-    u_kstar = np.ascontiguousarray(u_kstar, dtype=np.float64)
-    u_k = np.ascontiguousarray(u_k, dtype=np.float64)
-    hkl = np.ascontiguousarray(hkl, dtype=np.float64)
-    uvw = np.ascontiguousarray(uvw, dtype=np.float64)
-
-    band_coords, zone_axes_coords = _bands_and_zone_axes_kernel(
-        hkl, uvw, u_kstar, u_k, max_r_gnomonic
-    )
-
-    return band_coords, zone_axes_coords
 
 
 def _get_zone_axes_from_hkl(hkl: np.ndarray) -> np.ndarray:
@@ -229,14 +166,39 @@ def _get_geometrical_simulation(
         (x, y) positions of visible zone axes in the requested
         coordinate system, shape (l, 2).
     """
-    # Setup
+    # Setup row vectors (n, 3) and row matrices (3, 3)
     lattice: dst.Lattice = reflectors.phase.structure.lattice
-    hkl = reflectors.hkl.astype(float).reshape(-1, 3)
     base = np.asarray(lattice.base).reshape(3, 3)
-    recbase = np.asarray(lattice.recbase).reshape(3, 3)
-    rotation_matrix = rotation.to_matrix().squeeze()
-    u_s = (~detector.sample_to_detector).to_matrix().squeeze()
+    recbase = np.asarray(lattice.recbase).reshape(3, 3).T
+    hkl = np.ascontiguousarray(reflectors.hkl.reshape(-1, 3), dtype=np.float64)
+    u_o = rotation.to_matrix().squeeze()  # Sample -> crystal
+    u_s = detector.sample_to_detector.to_matrix().squeeze().T
+
+    # Crystal -> sample -> detector
+    u_os = u_o @ u_s
+
+    # Reciprocal lattice -> crystal -> sample -> detector
+    u_kstar = recbase @ u_os
+
+    # Direct lattice -> crystal -> sample -> detector
+    u_k = base @ u_os
+
+    u_kstar = np.ascontiguousarray(u_kstar, dtype=np.float64)
+    u_k = np.ascontiguousarray(u_k, dtype=np.float64)
+
+    if uvw is None:
+        uvw = _get_zone_axes_from_hkl(hkl)
+    uvw = np.ascontiguousarray(uvw, dtype=np.float64)
+
     max_r_gnomonic = np.float64(np.max(detector.r_max))
+
+    band_gnomonic, za_gnomonic = _bands_and_zone_axes_kernel(
+        hkl=hkl,
+        uvw=uvw,
+        u_kstar=u_kstar,
+        u_k=u_k,
+        max_r=max_r_gnomonic,
+    )
 
     # PC components and detector scales (needed for both coordinate
     # formats to filter zone axes by rectangular detector bounds)
@@ -251,19 +213,6 @@ def _get_geometrical_simulation(
     x_range[1] += x_scale
     y_range[0] -= y_scale
     y_range[1] += y_scale
-
-    if uvw is None:
-        uvw = _get_zone_axes_from_hkl(hkl)
-
-    band_gnomonic, za_gnomonic = _get_geometrical_bands_and_zone_axes_gnomonic(
-        hkl=hkl,
-        uvw=uvw,
-        base=base,
-        recbase=recbase,
-        rotation_matrix=rotation_matrix,
-        u_s=u_s,
-        max_r_gnomonic=max_r_gnomonic,
-    )
 
     if coords_fmt == "gnomonic":
         if za_gnomonic.shape[0] == 0:

--- a/src/kikuchipy/simulations/_geometrical_simulation.py
+++ b/src/kikuchipy/simulations/_geometrical_simulation.py
@@ -135,8 +135,8 @@ def _get_geometrical_bands_and_zone_axes_gnomonic(
         Crystal orientation rotation matrix (3, 3), from
         ``rotation.to_matrix().squeeze()``.
     u_s
-        Sample-to-detector rotation matrix (3, 3), from
-        ``detector.sample_to_detector.to_matrix().squeeze()``.
+        Detector-to-sample rotation matrix (3, 3), from
+        ``(~detector.sample_to_detector).to_matrix().squeeze()``.
     max_r_gnomonic
         Maximum gnomonic radius. Default is 10.0.
 
@@ -206,9 +206,9 @@ def _get_geometrical_simulation(
     rotation
         Single crystal orientation.
     uvw
-        Pre-computed zone axis directions, shape (m, 3). If not given
-        (default), they are derived as pairwise cross products of the
-        *reflectors* hkl indices.
+        Pre-computed zone axis directions as row vectors, shape (m, 3).
+        If not given (default), they are derived as pairwise cross
+        products of the *reflectors* hkl indices.
 
         Pass a pre-computed array when calling this function repeatedly
         with the same *reflectors* to avoid redundant work.
@@ -235,7 +235,7 @@ def _get_geometrical_simulation(
     base = np.asarray(lattice.base).reshape(3, 3)
     recbase = np.asarray(lattice.recbase).reshape(3, 3)
     rotation_matrix = rotation.to_matrix().squeeze()
-    u_s = detector.sample_to_detector.to_matrix().squeeze()
+    u_s = (~detector.sample_to_detector).to_matrix().squeeze()
     max_r_gnomonic = np.float64(np.max(detector.r_max))
 
     # PC components and detector scales (needed for both coordinate

--- a/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
+++ b/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
@@ -251,27 +251,25 @@ class KikuchiPatternSimulator:
                 "`detector.navigation_shape` is not (1,) or equal to `rotations.shape`"
             )
 
+        # Set up row vectors (n, 3) and row matrices (3, 3)
         lattice = self.phase.structure.lattice
         ref = self._reflectors
         hkl = ref.hkl
 
-        # Transformation from detector reference frame CSd to sample
-        # reference frame CSs.
-        u_s = da.from_array(detector.sample_to_detector.to_matrix().squeeze())
+        # Sample -> detector
+        u_s = da.from_array(detector.sample_to_detector.to_matrix().squeeze().T)
 
-        # Transformation from CSs to cartesian crystal reference frame
-        # CSc
+        # Crystal -> sample -> detector
         u_o = da.from_array(rotations.to_matrix())
         u_os = da.matmul(u_o, u_s)
 
-        # Transformation from CSc to reciprocal crystal reference frame
-        # CSk*
+        # Reciprocal lattice -> crystal
         u_astar = da.from_array(lattice.recbase.T)
 
-        # Combine transformations
+        # Reciprocal lattice -> crystal -> sample -> detector
         u_kstar = da.matmul(u_astar, u_os)
 
-        # Transform {hkl} from CSk* to CSd
+        # {hkl} from reciprocal lattice -> detector
         hkl_d = da.matmul(da.from_array(hkl), u_kstar)
 
         nav_axes = (0, 1)[: rotations.ndim]
@@ -298,13 +296,13 @@ class KikuchiPatternSimulator:
         uvw_miller = uvw_miller.round()
         uvw_miller = uvw_miller.unique()
 
-        # Transformation from CSc to direct crystal reference frame CSk
+        # Direct lattice -> crystal
         u_a = da.from_array(lattice.base)
 
-        # Combine transformations
+        # Direct lattice -> crystal -> sample -> detector
         u_k = da.matmul(u_a, u_os)
 
-        # Transform direct lattice vectors from CSk to CSd
+        # <uvw> from direct lattice -> detector
         uvw_d = da.matmul(da.from_array(uvw_miller.uvw), u_k)
 
         # Find zone axes that are in some pattern

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -24,6 +24,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from orix.crystal_map import PhaseList
 import orix.quaternion as oqu
+import orix.vector as ove
 import pytest
 
 import kikuchipy as kp
@@ -257,9 +258,9 @@ class TestEBSDDetector:
     @pytest.mark.parametrize(
         "tilt, azimuthal, twist, sample_tilt, expected_rotation",
         [
-            (0, 0, 0, 90.0, [0.7071, 0.0, 0.0, 0.7071]),
-            (0, 0, 0, 70.0, [0.6964, 0.1228, 0.1228, 0.6964]),
-            (8.3, 4.7, -1.02, 70.0, [0.6861, 0.2021, 0.1428, 0.6841]),
+            (0, 0, 0, 90.0, [0.7071, 0.0, 0.0, -0.7071]),
+            (0, 0, 0, 70.0, [0.6964, -0.1228, -0.1228, -0.6964]),
+            (8.3, 4.7, -1.02, 70.0, [0.6861, -0.2021, -0.1428, -0.6841]),
         ],
     )
     def test_sample_to_detector(
@@ -272,6 +273,20 @@ class TestEBSDDetector:
         assert isinstance(rot_sample_to_det, oqu.Rotation)
         assert np.allclose(rot_sample_to_det.data, expected_rotation, atol=1e-4)
 
+    def test_sample_to_detector_numpy_comparison(self):
+        det = kp.detectors.EBSDDetector()
+        v = ove.Vector3d.random(4)
+
+        R_s2d = det.sample_to_detector
+        om_s2d = R_s2d.to_matrix().squeeze()
+        assert np.allclose((R_s2d * v).data, (om_s2d @ v.data.T).T, atol=1e-4)
+        assert np.allclose((R_s2d * v).data, np.dot(om_s2d, v.data.T).T, atol=1e-4)
+
+        R_d2s = ~R_s2d
+        om_d2s = R_d2s.to_matrix().squeeze()
+        assert np.allclose((R_d2s * v).data, (om_d2s @ v.data.T).T, atol=1e-4)
+        assert np.allclose((R_d2s * v).data, np.dot(om_d2s, v.data.T).T, atol=1e-4)
+
     @pytest.mark.parametrize("sample_tilt", [0.0, 70.0])
     def test_sample_to_detector_azimuthal_about_detector_y(self, sample_tilt):
         det = kp.detectors.EBSDDetector(
@@ -280,11 +295,11 @@ class TestEBSDDetector:
             azimuthal=0.0,
             twist=0.0,
         )
-        y0 = (~det.sample_to_detector).to_matrix().squeeze()[1]
+        y0 = det.sample_to_detector.to_matrix().squeeze()[1]
 
         for azimuthal in [20.0, -40.0]:
             det.azimuthal = azimuthal
-            y = (~det.sample_to_detector).to_matrix().squeeze()[1]
+            y = det.sample_to_detector.to_matrix().squeeze()[1]
             assert np.allclose(y, y0, atol=1e-8)
 
     @pytest.mark.parametrize(

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -730,15 +730,13 @@ class TestEstimateTilts:
             step_sizes=(50, 50),
         )
 
-        xtilt = det.estimate_xtilt(degrees=True)
+        xtilt, fig = det.estimate_xtilt(degrees=True, return_figure=True)
         assert np.isclose(xtilt, 90 - self.det0.sample_tilt + self.det0.tilt)
-        assert plt.get_fignums() == [1]
-        ax = plt.gca()
-        assert not any(["Outliers" in t.get_text() for t in ax.get_legend().texts])
-
-        xtilt, is_outliers, _ = det.estimate_xtilt(
-            return_outliers=True, return_figure=True
+        assert not any(
+            ["Outliers" in t.get_text() for t in fig.axes[0].get_legend().texts]
         )
+
+        xtilt, is_outliers = det.estimate_xtilt(return_outliers=True)
         assert isinstance(is_outliers, np.ndarray)
         assert is_outliers.sum() == 0
 

--- a/tests/test_detectors/test_ebsd_detector_signals.py
+++ b/tests/test_detectors/test_ebsd_detector_signals.py
@@ -19,7 +19,7 @@
 
 import pytest
 
-_ = pytest.importorskip("psygnal", reason="psygnal is not installed")
+_ = pytest.importorskip("psygnal.testing", reason="psygnal is not installed")
 
 import numpy as np
 import psygnal.testing as pt

--- a/tests/test_signals/test_ebsd_master_pattern.py
+++ b/tests/test_signals/test_ebsd_master_pattern.py
@@ -809,7 +809,7 @@ class TestFitPatternDetectorOrientation:
 
         sim_lines = self.simulator.on_detector(det, self.rotations)
 
-        u_os = np.matmul(self.u_o, det.sample_to_detector.to_matrix().squeeze())
+        u_os = np.matmul(self.u_o, det.sample_to_detector.to_matrix().squeeze().T)
 
         return det, sim_lines, u_os
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->

This PR adds an example showing how to interpret the detector sample -> detector rotation (introduced in 0.12.0). I've also updated the interpretation of most uses of it internally, clarifying why we sometimes transpose and sometimes not.

It also adds a citation file pointing to the pre-print on arxiv (https://arxiv.org/abs/2605.25722). Will be updated once the paper is published.

I'll release this as a patch release to get the message out.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
