### PR TITLE
Patch release 0.12.2 with fix for EDAX binary overflow error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
+0.12.2 (2026-06-05)
+===================
+
+Fixed
+-----
+- Overflow error when loading EDAX binary up1/up2 files greater than ~4 GB.
+
+
 0.12.1 (2026-05-30)
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,12 +13,13 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
-0.12.2 (2026-06-05)
+0.12.2 (2026-06-04)
 ===================
 
 Fixed
 -----
 - Overflow error when loading EDAX binary up1/up2 files greater than ~4 GB.
+  (`#804 <https://github.com/pyxem/kikuchipy/pull/804>`_)
 
 
 0.12.1 (2026-05-30)

--- a/src/kikuchipy/__init__.py
+++ b/src/kikuchipy/__init__.py
@@ -36,7 +36,7 @@ credits = [
     "Tijmen Vermeij",
 ]
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 

--- a/src/kikuchipy/io/plugins/edax_binary/_api.py
+++ b/src/kikuchipy/io/plugins/edax_binary/_api.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2026 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 """Reader of EBSD data from EDAX TSL UP1/2 files.
 
@@ -110,7 +112,10 @@ class EDAXBinaryFileReader:
     def read_header(self) -> dict[str, int]:
         """Return read header information."""
         self.file.seek(4)
-        sx, sy, pattern_offset = np.fromfile(self.file, "uint32", count=3)
+        sx, sy, pattern_offset = tuple(
+            map(int, np.fromfile(self.file, "uint32", count=3))
+        )
+
         file_size = Path(self.file.name).stat().st_size
 
         if self.version == 1:
@@ -120,7 +125,7 @@ class EDAXBinaryFileReader:
             dx, dy = 1, 1
             is_hex = False
         else:  # Version >= 3
-            nx, ny = np.fromfile(self.file, "uint32", 2, offset=1)
+            nx, ny = tuple(map(int, np.fromfile(self.file, "uint32", 2, offset=1)))
 
             is_hex = np.fromfile(self.file, "uint8", 1)[0]
             is_hex = bool(is_hex)


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Fixes https://github.com/pyxem/kikuchipy/issues/803.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
I could reproduce the error reported in #803. After converting the violating uint32 numbers to int, the error is no more.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
